### PR TITLE
Typo in sssp

### DIFF
--- a/examples/sssp/sssp.cu
+++ b/examples/sssp/sssp.cu
@@ -53,7 +53,7 @@ void test_sssp() {
   thrust::device_vector<weight_t> d_Ax = h_Ax;
 
   vertex_t source = 1;
-  thrust::device_vector<weight_t> d_distances(nnz);
+  thrust::device_vector<weight_t> d_distances(r);
 
   // calling sssp
   float elapsed = sssp::execute<space>(r,           // number of vertices


### PR DESCRIPTION
`d_distances` is a vector of distances from the source vertex to all other vertices -- so it only needs to be `num_nodes` long, not `num_edges`