### PR TITLE
Port properties in from Gunrock main repo

### DIFF
--- a/gunrock/cuda/device_properties.hxx
+++ b/gunrock/cuda/device_properties.hxx
@@ -150,7 +150,9 @@ inline constexpr unsigned sm_registers(compute_capability_t capability) {
  * @todo Test if this function can be resolved at compile time
  */
 template<enum cudaFuncCache sm3XCacheConfig = cudaFuncCachePreferNone>
-inline constexpr unsigned sm_max_smem_bytes(compute_capability_t capability) {
+inline constexpr unsigned sm_max_shared_memory_bytes(
+  compute_capability_t capability
+) {
   unsigned sm3XConfiguredSmem =
     (sm3XCacheConfig == cudaFuncCachePreferNone)   ? 48 * KiB :
     (sm3XCacheConfig == cudaFuncCachePreferShared) ? 48 * KiB :

--- a/gunrock/cuda/device_properties.hxx
+++ b/gunrock/cuda/device_properties.hxx
@@ -11,6 +11,7 @@
 #pragma once
 #include <iostream>
 #include <gunrock/cuda/device.hxx>
+#include <gunrock/error.hxx>
 
 namespace gunrock {
 namespace cuda {

--- a/gunrock/cuda/device_properties.hxx
+++ b/gunrock/cuda/device_properties.hxx
@@ -60,6 +60,21 @@ enum : size_t {
   K   = 1024
 };
 
+/**
+ * @brief Architecture name based on compute capability.
+ * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capability
+ */
+inline constexpr const char* arch_name(compute_capability_t capability) {
+  return
+    (capability.major == 8) ?  "Ampere" :
+    (capability.major == 7 && capability.minor == 5) ? "Turing" :
+    (capability.major == 7) ?   "Volta" :
+    (capability.major == 6) ?  "Pascal" :
+    (capability.major == 5) ? "Maxwell" :
+    (capability.major == 3) ?  "Kepler" :
+                                nullptr ;
+}
+
 // Device properties retrieved from:
 // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications
 

--- a/gunrock/cuda/device_properties.hxx
+++ b/gunrock/cuda/device_properties.hxx
@@ -34,6 +34,9 @@ typedef struct {
 
 /**
  * @brief Get compute capability from major and minor versions.
+ * @param major Compute capability major version
+ * @param minor Compute capability minor version
+ * \return compute_capability_t
  */
 constexpr compute_capability_t make_compute_capability(unsigned major,
                                                        unsigned minor) {
@@ -42,6 +45,8 @@ constexpr compute_capability_t make_compute_capability(unsigned major,
 
 /**
  * @brief Get compute capability from combined major and minor version.
+ * @param combined Combined major and minor value, e.g. 86 for 8.6
+ * \return compute_capability_t
  */
 constexpr compute_capability_t make_compute_capability(unsigned combined) {
   return compute_capability_t{combined / 10, combined % 10};
@@ -63,6 +68,8 @@ enum : size_t {
 /**
  * @brief Architecture name based on compute capability.
  * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capability
+ * @param capability Compute capability from which to get the result
+ * \return const char* architecture name or nullptr if capability is invalid
  */
 inline constexpr const char* arch_name(compute_capability_t capability) {
   return
@@ -80,6 +87,7 @@ inline constexpr const char* arch_name(compute_capability_t capability) {
 
 /**
  * @brief Maximum number of threads per block.
+ * \return unsigned
  */
 inline constexpr unsigned cta_max_threads() {
   return 1 << 10;  // 1024 threads per CTA
@@ -87,6 +95,7 @@ inline constexpr unsigned cta_max_threads() {
 
 /**
  * @brief Warp size (has always been 32, but is subject to change).
+ * \return unsigned
  */
 inline constexpr unsigned warp_max_threads() {
   return 1 << 5;
@@ -94,6 +103,8 @@ inline constexpr unsigned warp_max_threads() {
 
 /**
  * @brief Maximum number of resident blocks per SM.
+ * @param capability Compute capability from which to get the result
+ * \return unsigned
  */
 inline constexpr unsigned sm_max_ctas(compute_capability_t capability) {
   return
@@ -106,6 +117,8 @@ inline constexpr unsigned sm_max_ctas(compute_capability_t capability) {
 
 /**
  * @brief Maximum number of resident threads per SM.
+ * @param capability Compute capability from which to get the result
+ * \return unsigned
  */
 inline constexpr unsigned sm_max_threads(compute_capability_t capability) {
   return
@@ -117,6 +130,8 @@ inline constexpr unsigned sm_max_threads(compute_capability_t capability) {
 
 /**
  * @brief Number of 32-bit registers per SM.
+ * @param capability Compute capability from which to get the result
+ * \return unsigned
  */
 inline constexpr unsigned sm_registers(compute_capability_t capability) {
   return
@@ -127,6 +142,12 @@ inline constexpr unsigned sm_registers(compute_capability_t capability) {
 
 /**
  * @brief Maximum amount of shared memory per SM.
+ * @tparam sm3XCacheConfig cudaFuncCache enum representing the shared data
+ *                         cache configuration used when called on compute
+ *                         capability 3.x
+ * @param capability       Compute capability from which to get the result
+ * \return unsigned
+ * @todo Test if this function can be resolved at compile time
  */
 template<enum cudaFuncCache sm3XCacheConfig = cudaFuncCachePreferNone>
 inline constexpr unsigned sm_max_smem_bytes(compute_capability_t capability) {
@@ -153,6 +174,7 @@ inline constexpr unsigned sm_max_smem_bytes(compute_capability_t capability) {
 
 /**
  * @brief Number of shared memory banks.
+ * \return unsigned
  */
 inline constexpr unsigned shared_memory_banks() {
   return 1 << 5;  // 32 memory banks per SM
@@ -160,6 +182,7 @@ inline constexpr unsigned shared_memory_banks() {
 
 /**
  * @brief Stride length of shared memory in bytes.
+ * \return unsigned
  */
 inline constexpr unsigned shared_memory_bank_stride() {
   return 1 << 2;  // 4 byte words

--- a/gunrock/cuda/device_properties.hxx
+++ b/gunrock/cuda/device_properties.hxx
@@ -17,13 +17,104 @@ namespace gunrock {
 namespace cuda {
 
 typedef cudaDeviceProp device_properties_t;
-typedef int architecture_t;
+typedef struct {
+  const int cuda_arch_;
+  const int major = (int)(cuda_arch_ / 100);
+  const int minor = (cuda_arch_ / 10) % 10;
+  constexpr bool operator>=(const int &i) const { return cuda_arch_ >= i; }
+} architecture_t;
 
 /**
  * @namespace properties
  * C++ based CUDA device properties.
  */
 namespace properties {
+
+enum : size_t {
+  KiB = 1024,
+  K   = 1024
+};
+
+/**
+ * Device properties retrieved from:
+ * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications
+ */
+
+/**
+ * Maximum number of threads per block
+ */
+inline constexpr unsigned cta_max_threads() {
+  return 1 << 10;  // 1024 threads per CTA
+}
+
+/**
+ * Warp size
+ */
+inline constexpr unsigned warp_max_threads() {
+  return 1 << 5;  // 32 threads per warp
+}
+
+/**
+ * Maximum number of resident blocks per SM
+ */
+inline constexpr unsigned sm_max_ctas(architecture_t arch) {
+  return
+    (arch >= 860) ? 16 :  // SM86+
+    (arch >= 800) ? 32 :  // SM80
+    (arch >= 750) ? 16 :  // SM75
+    (arch >= 500) ? 32 :  // SM50-SM72
+                    16 ;  // SM30-SM37
+}
+
+/**
+ * Maximum number of resident threads per SM
+ */
+inline constexpr unsigned sm_max_threads(architecture_t arch) {
+  return
+    (arch >= 860) ? 1536 :  // SM86+
+    (arch >= 800) ? 2048 :  // SM80
+    (arch >= 750) ? 1024 :  // SM75
+                    2048 ;  // SM30-SM72
+}
+
+/**
+ * Number of 32-bit registers per SM
+ */
+inline constexpr unsigned sm_registers(architecture_t arch) {
+  return
+    (arch >= 500) ?  64 * K :  // SM50+
+    (arch >= 370) ? 128 * K :  // SM37
+                     64 * K ;  // SM30-SM35
+}
+
+/**
+ * Maximum amount of shared memory per SM
+ */
+inline constexpr unsigned sm_max_smem_bytes(architecture_t arch) {
+  return
+    (arch >= 860) ? 100 * KiB :  // SM86+
+    (arch >= 800) ? 164 * KiB :  // SM80
+    (arch >= 750) ?  64 * KiB :  // SM75
+    (arch >= 700) ?  96 * KiB :  // SM70-SM72
+    (arch >= 620) ?  64 * KiB :  // SM62
+    (arch >= 610) ?  96 * KiB :  // SM61
+    (arch >= 530) ?  64 * KiB :  // SM53
+    (arch >= 520) ?  96 * KiB :  // SM52
+    (arch >= 500) ?  64 * KiB :  // SM50
+    (arch >= 370) ? 112 * KiB :  // SM37
+                     48 * KiB ;  // SM30-SM35
+}
+
+/**
+ * Number of shared memory banks
+ */
+inline constexpr unsigned shared_memory_banks() {
+  return 1 << 5;  // 32 memory banks per SM
+}
+
+inline constexpr unsigned shared_memory_bank_stride() {
+  return 1 << 2;  // 4 byte words
+}
 
 void print(device_properties_t& prop) {
   device_id_t ordinal;
@@ -49,18 +140,6 @@ void print(device_properties_t& prop) {
             << std::endl;
   std::cout << "ECC " << (prop.ECCEnabled ? "Enabled" : "Disabled")
             << std::endl;
-}
-
-inline constexpr unsigned shared_memory_banks() {
-  return 1 << 5;  // 32 memory banks per SM
-}
-
-inline constexpr unsigned shared_memory_bank_stride() {
-  return 1 << 2;  // 4 byte words
-}
-
-inline constexpr unsigned maximum_threads_per_warp() {
-  return 1 << 5;  // 32 threads per warp
 }
 
 }  // namespace properties

--- a/gunrock/cuda/device_properties.hxx
+++ b/gunrock/cuda/device_properties.hxx
@@ -128,10 +128,9 @@ inline constexpr unsigned sm_registers(compute_capability_t capability) {
 /**
  * @brief Maximum amount of shared memory per SM.
  */
-inline constexpr unsigned sm_max_smem_bytes(compute_capability_t capability,
-                                            enum cudaFuncCache sm3XCacheConfig
-                                            = cudaFuncCachePreferNone) {
-  unsigned sm3XConfigurableSharedMem =
+template<enum cudaFuncCache sm3XCacheConfig = cudaFuncCachePreferNone>
+inline constexpr unsigned sm_max_smem_bytes(compute_capability_t capability) {
+  unsigned sm3XConfiguredSmem =
     (sm3XCacheConfig == cudaFuncCachePreferNone)   ? 48 * KiB :
     (sm3XCacheConfig == cudaFuncCachePreferShared) ? 48 * KiB :
     (sm3XCacheConfig == cudaFuncCachePreferL1)     ? 16 * KiB :
@@ -148,8 +147,8 @@ inline constexpr unsigned sm_max_smem_bytes(compute_capability_t capability,
     (capability >= 53) ?  64 * KiB :  // SM53
     (capability >= 52) ?  96 * KiB :  // SM52
     (capability >= 50) ?  64 * KiB :  // SM50
-    (capability >= 37) ?  64 * KiB + sm3XConfigurableSharedMem :  // SM37
-         sm3XConfigurableSharedMem ;  // SM30-SM35
+    (capability >= 37) ?  64 * KiB + sm3XConfiguredSmem :  // SM37
+                sm3XConfiguredSmem ;  // SM30-SM35
 }
 
 /**

--- a/gunrock/cuda/device_properties.hxx
+++ b/gunrock/cuda/device_properties.hxx
@@ -181,11 +181,19 @@ inline constexpr unsigned shared_memory_banks() {
 }
 
 /**
- * @brief Stride length of shared memory in bytes.
+ * @brief Stride length (number of bytes per word) of shared memory in bytes.
+ * @tparam sm3XSmemConfig cudaSharedMemConfig enum representing the shared
+ *                        memory bank size (stride) used when called on compute
+ *                        capability 3.x
  * \return unsigned
  */
+template<enum cudaSharedMemConfig sm3XSmemConfig = cudaSharedMemBankSizeDefault>
 inline constexpr unsigned shared_memory_bank_stride() {
-  return 1 << 2;  // 4 byte words
+  return
+    (sm3XSmemConfig == cudaSharedMemBankSizeDefault)   ? 1 << 2 :
+    (sm3XSmemConfig == cudaSharedMemBankSizeFourByte)  ? 1 << 2 :
+    (sm3XSmemConfig == cudaSharedMemBankSizeEightByte) ? 1 << 3 :
+                                                         1 << 2 ;
 }
 
 void print(device_properties_t& prop) {

--- a/gunrock/cuda/device_properties.hxx
+++ b/gunrock/cuda/device_properties.hxx
@@ -189,6 +189,8 @@ inline constexpr unsigned shared_memory_banks() {
  */
 template<enum cudaSharedMemConfig sm3XSmemConfig = cudaSharedMemBankSizeDefault>
 inline constexpr unsigned shared_memory_bank_stride() {
+  // The default config on 3.x is the same constant value for later archs
+  // Only let 3.x be configurable if stride later becomes dependent on arch
   return
     (sm3XSmemConfig == cudaSharedMemBankSizeDefault)   ? 1 << 2 :
     (sm3XSmemConfig == cudaSharedMemBankSizeFourByte)  ? 1 << 2 :

--- a/gunrock/cuda/device_properties.hxx
+++ b/gunrock/cuda/device_properties.hxx
@@ -128,7 +128,16 @@ inline constexpr unsigned sm_registers(compute_capability_t capability) {
 /**
  * @brief Maximum amount of shared memory per SM.
  */
-inline constexpr unsigned sm_max_smem_bytes(compute_capability_t capability) {
+inline constexpr unsigned sm_max_smem_bytes(compute_capability_t capability,
+                                            enum cudaFuncCache sm3XCacheConfig
+                                            = cudaFuncCachePreferNone) {
+  unsigned sm3XConfigurableSharedMem =
+    (sm3XCacheConfig == cudaFuncCachePreferNone)   ? 48 * KiB :
+    (sm3XCacheConfig == cudaFuncCachePreferShared) ? 48 * KiB :
+    (sm3XCacheConfig == cudaFuncCachePreferL1)     ? 16 * KiB :
+    (sm3XCacheConfig == cudaFuncCachePreferEqual)  ? 32 * KiB :
+                                                     48 * KiB ;
+
   return
     (capability >= 86) ? 100 * KiB :  // SM86+
     (capability >= 80) ? 164 * KiB :  // SM80
@@ -139,8 +148,8 @@ inline constexpr unsigned sm_max_smem_bytes(compute_capability_t capability) {
     (capability >= 53) ?  64 * KiB :  // SM53
     (capability >= 52) ?  96 * KiB :  // SM52
     (capability >= 50) ?  64 * KiB :  // SM50
-    (capability >= 37) ? 112 * KiB :  // SM37
-                          48 * KiB ;  // SM30-SM35
+    (capability >= 37) ?  64 * KiB + sm3XConfigurableSharedMem :  // SM37
+         sm3XConfigurableSharedMem ;  // SM30-SM35
 }
 
 /**

--- a/unittests/device_properties/Makefile
+++ b/unittests/device_properties/Makefile
@@ -1,0 +1,15 @@
+include ../Makefile.inc
+
+APP = device_properties
+
+test: bin/$(APP)
+
+bin/$(APP) : test_$(APP).cu $(DEPS)
+	mkdir -p bin
+	$(NVCC) -ccbin=${CXX} ${NVCCFLAGS} ${NVCCOPT} --compiler-options "${CXXFLAGS} ${CXXOPT}" -o bin/$(APP) test_$(APP).cu $(SOURCE) $(ARCH) $(INC)
+
+debug : test_$(APP).cu $(DEPS)
+	mkdir -p bin
+	$(NVCC) -ccbin=${CXX} ${NVCCFLAGS} ${NVCCDEBUG} --compiler-options "${CXXFLAGS} ${CXXDEBUG}" -o bin/$(APP) test_$(APP).cu $(SOURCE) $(ARCH) $(INC)
+
+.DEFAULT_GOAL := test

--- a/unittests/device_properties/test_device_properties.cu
+++ b/unittests/device_properties/test_device_properties.cu
@@ -1,0 +1,27 @@
+#include <iostream>
+#include <string>
+#include <gunrock/cuda/device_properties.hxx>
+
+#ifdef __CUDA_ARCH__ // Device-side compilation
+#define GR_CUDA_ARCH __CUDA_ARCH__
+#else // Host-side compilation
+#define GR_CUDA_ARCH 300
+#endif
+
+int main(int argc, char** argv) {
+    using namespace std;
+    using namespace gunrock::cuda::properties;
+    int arch_val = (argc > 1) ? stoi(argv[1]) : 300;
+    gunrock::cuda::architecture_t arch{arch_val};
+    cout << "Architecture Version Major: " << arch.major << endl;
+    cout << "Architecture Version Minor: " << arch.minor << endl;
+    cout << endl;
+    cout << "cta_max_threads:           " << cta_max_threads() << endl;
+    cout << "warp_max_threads:          " << warp_max_threads() << endl;
+    cout << "sm_max_ctas:               " << sm_max_ctas(arch) << endl;
+    cout << "sm_max_threads:            " << sm_max_threads(arch) << endl;
+    cout << "sm_registers:              " << sm_registers(arch) << endl;
+    cout << "sm_max_smem_bytes:         " << sm_max_smem_bytes(arch) << endl;
+    cout << "shared_memory_banks:       " << shared_memory_banks() << endl;
+    cout << "shared_memory_bank_stride: " << shared_memory_bank_stride() << endl;
+}

--- a/unittests/device_properties/test_device_properties.cu
+++ b/unittests/device_properties/test_device_properties.cu
@@ -3,27 +3,27 @@
 #include <gunrock/cuda/device_properties.hxx>
 
 int main(int argc, char** argv) {
-    using namespace std;
-    using namespace gunrock::cuda;
-    using namespace gunrock::cuda::properties;
+  using namespace std;
+  using namespace gunrock::cuda;
+  using namespace gunrock::cuda::properties;
 
-    int cc_ver = (argc > 1) ? stoi(argv[1]) : 30;
-    compute_capability_t cc = make_compute_capability(cc_ver);
-    const char *arch = arch_name(cc);
+  int cc_ver = (argc > 1) ? stoi(argv[1]) : 30;
+  compute_capability_t cc = make_compute_capability(cc_ver);
+  const char *arch = arch_name(cc);
 
-    cout << "Compute Capability Version Major: " << cc.major << endl;
-    cout << "Compute Capability Version Minor: " << cc.minor << endl;
+  cout << "Compute Capability Version Major: " << cc.major << endl;
+  cout << "Compute Capability Version Minor: " << cc.minor << endl;
 
-    if (arch != nullptr)
-        cout << "Compute Capability Architecture: " << arch << endl;
+  if (arch != nullptr)
+    cout << "Compute Capability Architecture: " << arch << endl;
 
-    cout << endl;
-    cout << "cta_max_threads:           " << cta_max_threads() << endl;
-    cout << "warp_max_threads:          " << warp_max_threads() << endl;
-    cout << "sm_max_ctas:               " << sm_max_ctas(cc) << endl;
-    cout << "sm_max_threads:            " << sm_max_threads(cc) << endl;
-    cout << "sm_registers:              " << sm_registers(cc) << endl;
-    cout << "sm_max_smem_bytes:         " << sm_max_smem_bytes(cc) << endl;
-    cout << "shared_memory_banks:       " << shared_memory_banks() << endl;
-    cout << "shared_memory_bank_stride: " << shared_memory_bank_stride() << endl;
+  cout << endl;
+  cout << "cta_max_threads:           " << cta_max_threads() << endl;
+  cout << "warp_max_threads:          " << warp_max_threads() << endl;
+  cout << "sm_max_ctas:               " << sm_max_ctas(cc) << endl;
+  cout << "sm_max_threads:            " << sm_max_threads(cc) << endl;
+  cout << "sm_registers:              " << sm_registers(cc) << endl;
+  cout << "sm_max_smem_bytes:         " << sm_max_smem_bytes(cc) << endl;
+  cout << "shared_memory_banks:       " << shared_memory_banks() << endl;
+  cout << "shared_memory_bank_stride: " << shared_memory_bank_stride() << endl;
 }

--- a/unittests/device_properties/test_device_properties.cu
+++ b/unittests/device_properties/test_device_properties.cu
@@ -2,10 +2,17 @@
 #include <string>
 #include <gunrock/cuda/device_properties.hxx>
 
+using namespace gunrock::cuda;
+using namespace gunrock::cuda::properties;
+
+// Making sure the CUDA API enums are known at compile time
+compute_capability_t sm30 = make_compute_capability(30);
+size_t smem_size = sm_max_smem_bytes<cudaFuncCachePreferEqual>(sm30);
+size_t smem_bank_stride =
+  shared_memory_bank_stride<cudaSharedMemBankSizeEightByte>();
+
 int main(int argc, char** argv) {
   using namespace std;
-  using namespace gunrock::cuda;
-  using namespace gunrock::cuda::properties;
 
   int cc_ver = (argc > 1) ? stoi(argv[1]) : 30;
   compute_capability_t cc = make_compute_capability(cc_ver);

--- a/unittests/device_properties/test_device_properties.cu
+++ b/unittests/device_properties/test_device_properties.cu
@@ -6,10 +6,17 @@ int main(int argc, char** argv) {
     using namespace std;
     using namespace gunrock::cuda;
     using namespace gunrock::cuda::properties;
+
     int cc_ver = (argc > 1) ? stoi(argv[1]) : 30;
     compute_capability_t cc = make_compute_capability(cc_ver);
+    const char *arch = arch_name(cc);
+
     cout << "Compute Capability Version Major: " << cc.major << endl;
     cout << "Compute Capability Version Minor: " << cc.minor << endl;
+
+    if (arch != nullptr)
+        cout << "Compute Capability Architecture: " << arch << endl;
+
     cout << endl;
     cout << "cta_max_threads:           " << cta_max_threads() << endl;
     cout << "warp_max_threads:          " << warp_max_threads() << endl;

--- a/unittests/device_properties/test_device_properties.cu
+++ b/unittests/device_properties/test_device_properties.cu
@@ -2,26 +2,21 @@
 #include <string>
 #include <gunrock/cuda/device_properties.hxx>
 
-#ifdef __CUDA_ARCH__ // Device-side compilation
-#define GR_CUDA_ARCH __CUDA_ARCH__
-#else // Host-side compilation
-#define GR_CUDA_ARCH 300
-#endif
-
 int main(int argc, char** argv) {
     using namespace std;
+    using namespace gunrock::cuda;
     using namespace gunrock::cuda::properties;
-    int arch_val = (argc > 1) ? stoi(argv[1]) : 300;
-    gunrock::cuda::architecture_t arch{arch_val};
-    cout << "Architecture Version Major: " << arch.major << endl;
-    cout << "Architecture Version Minor: " << arch.minor << endl;
+    int cc_ver = (argc > 1) ? stoi(argv[1]) : 30;
+    compute_capability_t cc = make_compute_capability(cc_ver);
+    cout << "Compute Capability Version Major: " << cc.major << endl;
+    cout << "Compute Capability Version Minor: " << cc.minor << endl;
     cout << endl;
     cout << "cta_max_threads:           " << cta_max_threads() << endl;
     cout << "warp_max_threads:          " << warp_max_threads() << endl;
-    cout << "sm_max_ctas:               " << sm_max_ctas(arch) << endl;
-    cout << "sm_max_threads:            " << sm_max_threads(arch) << endl;
-    cout << "sm_registers:              " << sm_registers(arch) << endl;
-    cout << "sm_max_smem_bytes:         " << sm_max_smem_bytes(arch) << endl;
+    cout << "sm_max_ctas:               " << sm_max_ctas(cc) << endl;
+    cout << "sm_max_threads:            " << sm_max_threads(cc) << endl;
+    cout << "sm_registers:              " << sm_registers(cc) << endl;
+    cout << "sm_max_smem_bytes:         " << sm_max_smem_bytes(cc) << endl;
     cout << "shared_memory_banks:       " << shared_memory_banks() << endl;
     cout << "shared_memory_bank_stride: " << shared_memory_bank_stride() << endl;
 }


### PR DESCRIPTION
### Summary
Ports in device properties from Gunrock's [`cuda_properties.cuh`](https://github.com/gunrock/gunrock/blob/master/gunrock/util/cuda_properties.cuh) file. Makes use of the more modern `constexpr` specifier to avoid using confusing macros and instead functions that are resolved at compile time.

This change is based off of the [cuda-api-wrappers solution](https://github.com/eyalroz/cuda-api-wrappers/blob/master/src/cuda/api/detail/device_properties.hpp). Their implementation is more complex so if we need to evolve how device properties work for Gunrock we can first look there.

### Inconsistencies with device property values
I used the [compute capability tech specs in the CUDA documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications) to add the Ampere architectures and noticed some of the device property values in the old `cuda_properties.cuh` were inconsistent with what I saw in the documentation. I was originally using the values output by the [occupancy calculator excel sheet](https://docs.nvidia.com/cuda/cuda-occupancy-calculator/index.html) which **did** line up with what I saw in `cuda_properties.cuh`, but when I saw the docs had different values I trusted those more.

Let me know if any of the arch values should be changed.