### PR TITLE
hotfix architecture_t

### DIFF
--- a/gunrock/cuda/device_properties.hxx
+++ b/gunrock/cuda/device_properties.hxx
@@ -17,6 +17,7 @@ namespace gunrock {
 namespace cuda {
 
 typedef cudaDeviceProp device_properties_t;
+typedef int architecture_t;
 
 typedef struct {
   unsigned major;


### PR DESCRIPTION
Fix compilation error:
```
../../gunrock/cuda/context.hxx(48): error: namespace "gunrock::cuda" has no member "architecture_t"
```