### PR TITLE
Binary CSR write + read

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,4 +4,5 @@ add_subdirectory(bfs)
 add_subdirectory(color)
 add_subdirectory(geo)
 add_subdirectory(pr)
+add_subdirectory(mtx2bin)
 # end /* Add examples' subdirectories */

--- a/examples/mtx2bin/CMakeLists.txt
+++ b/examples/mtx2bin/CMakeLists.txt
@@ -1,0 +1,21 @@
+# begin /* Set the application name. */
+set(APPLICATION_NAME mtx2bin)
+# end /* Set the application name. */
+
+# begin /* Add CUDA executables */
+add_executable(${APPLICATION_NAME})
+
+set(SOURCE_LIST 
+    ${APPLICATION_NAME}.cu
+)
+
+target_sources(${APPLICATION_NAME} PRIVATE ${SOURCE_LIST})
+target_link_libraries(${APPLICATION_NAME} PRIVATE essentials)
+get_target_property(ESSENTIALS_ARCHITECTURES essentials CUDA_ARCHITECTURES)
+set_target_properties(${APPLICATION_NAME} 
+    PROPERTIES 
+        CUDA_ARCHITECTURES ${ESSENTIALS_ARCHITECTURES}
+) # XXX: Find a better way to inherit essentials properties.
+
+message("-- Example Added: ${APPLICATION_NAME}")
+# end /* Add CUDA executables */

--- a/examples/mtx2bin/mtx2bin.cu
+++ b/examples/mtx2bin/mtx2bin.cu
@@ -1,0 +1,44 @@
+#include <cstdlib>  // EXIT_SUCCESS
+
+#include <gunrock/applications/application.hxx>
+
+using namespace gunrock;
+using namespace memory;
+
+void test_mtx2bin(int num_arguments, char** argument_array) {
+  if (num_arguments != 2) {
+    std::cerr << "usage: ./bin/mtx2bin <inpath>" << std::endl;
+    exit(1);
+  }
+
+  // --
+  // Define types
+
+  using vertex_t = int;
+  using edge_t = int;
+  using weight_t = float;
+
+  // --
+  // IO
+
+  std::string inpath  = argument_array[1];
+  std::string outpath = inpath + ".csr";
+
+  io::matrix_market_t<vertex_t, edge_t, weight_t> mm;
+
+  using csr_t = format::csr_t<memory::memory_space_t::device, vertex_t, edge_t, weight_t>;
+  csr_t csr;
+  csr.from_coo(mm.load(inpath));
+
+  std::cout << "csr.number_of_rows     = " << csr.number_of_rows     << std::endl;
+  std::cout << "csr.number_of_columns  = " << csr.number_of_columns  << std::endl;
+  std::cout << "csr.number_of_nonzeros = " << csr.number_of_nonzeros << std::endl;
+  std::cout << "writing to             = " << outpath                << std::endl;
+
+  csr.write_binary(outpath);
+}
+
+int main(int argc, char** argv) {
+  test_mtx2bin(argc, argv);
+  return EXIT_SUCCESS;
+}

--- a/examples/pr/pr.cu
+++ b/examples/pr/pr.cu
@@ -16,18 +16,24 @@ void test_sssp(int num_arguments, char** argument_array) {
   using edge_t = int;
   using weight_t = float;
 
+  using csr_t = format::csr_t<memory_space_t::device, vertex_t, edge_t, weight_t>;
+  csr_t csr;
+  
   // --
   // IO
 
   std::string filename = argument_array[1];
-
-  io::matrix_market_t<vertex_t, edge_t, weight_t> mm;
-
-  using csr_t =
-      format::csr_t<memory_space_t::device, vertex_t, edge_t, weight_t>;
-  csr_t csr;
-  csr.from_coo(mm.load(filename));
-
+   
+  if(util::is_market(filename)) {
+    io::matrix_market_t<vertex_t, edge_t, weight_t> mm;
+    csr.from_coo(mm.load(filename));
+  } else if(util::is_binary_csr(filename)) {
+    csr.read_binary(filename);
+  } else {
+    std::cerr << "Unknown file format: " << filename << std::endl;
+    exit(1);
+  }
+  
   // --
   // Build graph
 

--- a/include/gunrock/formats/csr.hxx
+++ b/include/gunrock/formats/csr.hxx
@@ -144,6 +144,73 @@ struct csr_t {
     return *this;  // CSR representation (with possible duplicates)
   }
 
+  void read_binary(std::string filename) {
+    FILE* file = fopen(filename.c_str(), "rb");
+
+    // Read metadata
+    fread(&number_of_rows,     sizeof(index_t),  1, file);
+    fread(&number_of_columns,  sizeof(index_t),  1, file);
+    fread(&number_of_nonzeros, sizeof(offset_t), 1, file);
+
+    row_offsets.resize(number_of_rows + 1);
+    column_indices.resize(number_of_nonzeros);
+    nonzero_values.resize(number_of_nonzeros);
+
+    if(space == memory_space_t::device) {
+      assert(space == memory_space_t::device);
+
+      thrust::host_vector<offset_t> h_row_offsets(number_of_rows + 1);
+      thrust::host_vector<index_t> h_column_indices(number_of_nonzeros);
+      thrust::host_vector<value_t> h_nonzero_values(number_of_nonzeros);
+
+      fread(memory::raw_pointer_cast(h_row_offsets.data()),     sizeof(offset_t), number_of_rows + 1, file);
+      fread(memory::raw_pointer_cast(h_column_indices.data()),  sizeof(index_t),  number_of_nonzeros, file);
+      fread(memory::raw_pointer_cast(h_nonzero_values.data()),  sizeof(value_t),  number_of_nonzeros, file);
+
+      // Copy data from host to device
+      row_offsets    = h_row_offsets;
+      column_indices = h_column_indices;
+      nonzero_values = h_nonzero_values;
+
+    } else {
+      assert(space == memory_space_t::host);
+
+      fread(memory::raw_pointer_cast(row_offsets.data()),     sizeof(offset_t), number_of_rows + 1, file);
+      fread(memory::raw_pointer_cast(column_indices.data()),  sizeof(index_t),  number_of_nonzeros, file);
+      fread(memory::raw_pointer_cast(nonzero_values.data()),  sizeof(value_t),  number_of_nonzeros, file);      
+    }
+  }
+  
+  void write_binary(std::string filename) {
+    FILE* file = fopen(filename.c_str(), "wb");
+
+    // Write metadata
+    fwrite(&number_of_rows,      sizeof(index_t),  1, file);
+    fwrite(&number_of_columns,   sizeof(index_t),  1, file);
+    fwrite(&number_of_nonzeros,  sizeof(offset_t), 1, file);
+
+    // Write data
+    if(space == memory_space_t::device) {
+      assert(space == memory_space_t::device);
+
+      thrust::host_vector<offset_t> h_row_offsets(row_offsets);
+      thrust::host_vector<index_t> h_column_indices(column_indices);
+      thrust::host_vector<value_t> h_nonzero_values(nonzero_values);
+
+      fwrite(memory::raw_pointer_cast(h_row_offsets.data()),    sizeof(offset_t), number_of_rows + 1, file);
+      fwrite(memory::raw_pointer_cast(h_column_indices.data()), sizeof(index_t),  number_of_nonzeros, file);
+      fwrite(memory::raw_pointer_cast(h_nonzero_values.data()), sizeof(value_t),  number_of_nonzeros, file);
+    } else {
+      assert(space == memory_space_t::host);
+
+      fwrite(memory::raw_pointer_cast(row_offsets.data()),    sizeof(offset_t), number_of_rows + 1, file);
+      fwrite(memory::raw_pointer_cast(column_indices.data()), sizeof(index_t),  number_of_nonzeros, file);
+      fwrite(memory::raw_pointer_cast(nonzero_values.data()), sizeof(value_t),  number_of_nonzeros, file);
+    }
+
+    fclose(file);
+  }
+  
 };  // struct csr_t
 
 }  // namespace format

--- a/include/gunrock/util/filepath.hxx
+++ b/include/gunrock/util/filepath.hxx
@@ -15,5 +15,16 @@ std::string extract_dataset(std::string filename) {
   return filename.substr(0, lastindex);
 }
 
+bool is_market(std::string filename) {
+  return (
+    (filename.substr(filename.size() - 4) == ".mtx" ) ||
+    (filename.substr(filename.size() - 5) == ".mmio")
+  );
+}
+
+bool is_binary_csr(std::string filename) {
+  return filename.substr(filename.size() - 4) == ".csr";
+}
+
 }  // namespace util
 }  // namespace gunrock


### PR DESCRIPTION
Write and read simple binary CSR format.  Hugely reduces loading times.  

Example usage: https://github.com/bkj/essentials/blob/dev/binary_csr/examples/pr/pr.cu

```
$ time ./bin/pr rmat20.mtx
real    0m28.302s
user    0m27.296s
sys     0m0.924s
```
vs
```
$ ./bin/mtx2bin rmat20.mtx
$ time ./bin/pr rmat20.mtx.csr
real    0m0.664s
user    0m0.324s
sys     0m0.295s
```

In this example, loading time is cut from ~ 27.5 seconds to ~ 0.1 seconds.

Even if this isn't perfect (eg, only supports CSR right now), I'd recommend merging it so people can use the binary loaders during testing.  