### PR TITLE
Error in csr get_source_vertex

### DIFF
--- a/bug.mtx
+++ b/bug.mtx
@@ -1,0 +1,5 @@
+%%MatrixMarket matrix coordinate pattern symmetric
+3 3 3
+1 2
+1 3
+2 3

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,4 +4,5 @@ add_subdirectory(bfs)
 add_subdirectory(color)
 add_subdirectory(geo)
 add_subdirectory(pr)
+add_subdirectory(src_vertex_test)
 # end /* Add examples' subdirectories */

--- a/examples/src_vertex_test/CMakeLists.txt
+++ b/examples/src_vertex_test/CMakeLists.txt
@@ -1,0 +1,21 @@
+# begin /* Set the application name. */
+set(APPLICATION_NAME src_vertex_test)
+# end /* Set the application name. */
+
+# begin /* Add CUDA executables */
+add_executable(${APPLICATION_NAME})
+
+set(SOURCE_LIST 
+    ${APPLICATION_NAME}.cu
+)
+
+target_sources(${APPLICATION_NAME} PRIVATE ${SOURCE_LIST})
+target_link_libraries(${APPLICATION_NAME} PRIVATE essentials)
+get_target_property(ESSENTIALS_ARCHITECTURES essentials CUDA_ARCHITECTURES)
+set_target_properties(${APPLICATION_NAME} 
+    PROPERTIES 
+        CUDA_ARCHITECTURES ${ESSENTIALS_ARCHITECTURES}
+) # XXX: Find a better way to inherit essentials properties.
+
+message("-- Example Added: ${APPLICATION_NAME}")
+# end /* Add CUDA executables */

--- a/examples/src_vertex_test/src_vertex_test.cu
+++ b/examples/src_vertex_test/src_vertex_test.cu
@@ -1,0 +1,59 @@
+#include <gunrock/applications/application.hxx>
+
+using namespace gunrock;
+using namespace memory;
+
+void test_get_source_vertex(int num_arguments, char** argument_array) {
+  if (num_arguments != 2) {
+    std::cerr << "usage: ./bin/<program-name> filename.mtx" << std::endl;
+    exit(1);
+  }
+
+  // --
+  // Define types
+
+  using vertex_t = int;
+  using edge_t = int;
+  using weight_t = float;
+
+  // --
+  // IO
+
+  std::string filename = argument_array[1];
+
+  io::matrix_market_t<vertex_t, edge_t, weight_t> mm;
+
+  using csr_t =
+      format::csr_t<memory_space_t::device, vertex_t, edge_t, weight_t>;
+  csr_t csr;
+  
+  csr.from_coo(mm.load(filename));
+
+  // --
+  // Build graph
+
+  auto G = graph::build::from_csr<memory_space_t::device, graph::view_t::csr>(
+      csr.number_of_rows,               // rows
+      csr.number_of_columns,            // columns
+      csr.number_of_nonzeros,           // nonzeros
+      csr.row_offsets.data().get(),     // row_offsets
+      csr.column_indices.data().get(),  // column_indices
+      csr.nonzero_values.data().get()   // values
+  );  // supports row_indices and column_offsets (default = nullptr)
+
+
+  auto multi_context = std::shared_ptr<cuda::multi_context_t>(new cuda::multi_context_t(0));
+
+  auto log_edge = [G] __device__(edge_t const& e) -> void {
+    auto src = G.get_source_vertex(e);
+    auto dst = G.get_destination_vertex(e);
+    printf("%d %d %d\n", e, src, dst);
+  };
+
+  operators::parallel_for::execute<operators::parallel_for_each_t::edge>(
+      G, log_edge, *multi_context);
+}
+
+int main(int argc, char** argv) {
+  test_get_source_vertex(argc, argv);
+}

--- a/include/gunrock/graph/csr.hxx
+++ b/include/gunrock/graph/csr.hxx
@@ -56,8 +56,22 @@ class graph_csr_t {
   __host__ __device__ __forceinline__ vertex_type
   get_source_vertex(edge_type const& e) const {
     // XXX: I am dumb, idk if this is upper or lower bound?
-    return (vertex_type)algo::search::binary::upper_bound(
-        get_row_offsets(), e, this->number_of_vertices);
+    // return (vertex_type)algo::search::binary::upper_bound(
+    //     get_row_offsets(), e, this->number_of_vertices);
+    
+    auto keys = get_row_offsets();
+    auto key  = e;
+    
+    // returns `it` such that everything to the left is <= e.
+    // This will be one element to the right of the node id.
+    auto it = algo::search::binary::lower_bound(
+        thrust::counting_iterator<edge_t>(0),
+        thrust::counting_iterator<edge_t>(this->number_of_vertices), key,
+        [keys] __host__ __device__(const edge_t& pivot, const edge_t& key) {
+          return keys[pivot] <= key;
+        });
+    
+    return (*it) - 1;
   }
 
   __host__ __device__ __forceinline__ vertex_type


### PR DESCRIPTION
I _think_ the implementation of `csr.get_source_vertex` was incorrect, and I _think_ this fixes the bug -- though keeping track of the indices is a little tricky, so check my work.

You want to find the index `i` such that everything to the left of `i` is less than or equal to the edge index.  This is equal to `src + 1`. 

I tested this w/ a couple of small graphs that have zero degree nodes at the beginning, in the middle, and at the end -- should work for all of them.

```
$ cd build ; cmake .. ; make src_vertex_test -j12
$ cat ../bug.mtx
%%MatrixMarket matrix coordinate pattern symmetric
3 3 3
1 2
1 3
2 3

# w/ old version -- this is wrong (no 0? 1 and 3 have degree 3? vertex 3 exists?) 
$ ./bin/src_vertex_test ../bug.mtx
0 1 1
1 3 2
2 3 0
3 3 2
4 1 0
5 1 1

# new version -- this is correct (nodes 0, 1, 2 all have degree 2)
$ ./bin/src_vertex_test ../bug.mtx
0 0 1
1 0 2
2 1 0
3 1 2
4 2 0
5 2 1
```