### PR TITLE
Add print::head utility function

### DIFF
--- a/examples/color/color.cu
+++ b/examples/color/color.cu
@@ -48,16 +48,15 @@ void test_color(int num_arguments, char** argument_array) {
   // --
   // Run problem
 
-  float elapsed = gunrock::color::run(G, colors.data().get());
+  float gpu_elapsed = gunrock::color::run(G, colors.data().get());
 
   // --
   // Log
 
-  std::cout << "Colors (output) = ";
-  thrust::copy(colors.begin(), colors.end(),
-               std::ostream_iterator<weight_t>(std::cout, " "));
+  std::cout << "colors[:40] = ";
+  gunrock::print::head<weight_t>(colors, 40);
   std::cout << std::endl;
-  std::cout << "color Elapsed Time: " << elapsed << " (ms)" << std::endl;
+  std::cout << "GPU Elapsed Time: " << gpu_elapsed << " (ms)" << std::endl;
 }
 
 int main(int argc, char** argv) {

--- a/examples/pr/pr.cu
+++ b/examples/pr/pr.cu
@@ -60,19 +60,13 @@ void test_sssp(int num_arguments, char** argument_array) {
   // --
   // GPU Run
   
-  std::cout << "gunrock::pr::run -- starting" << std::endl;
   float gpu_elapsed = gunrock::pr::run(G, alpha, tol, p.data().get());
-  std::cout << "gunrock::pr::run -- complete" << std::endl;
 
   // --
   // Log + Validate
 
-  std::cout << "GPU p (output) = ";
-  thrust::copy(p.begin(),
-               (p.size() < 40) ? p.begin() + p.size()
-                                       : p.begin() + 40,
-               std::ostream_iterator<weight_t>(std::cout, " "));
-  std::cout << std::endl;
+  std::cout << "GPU p[:40] = ";
+  gunrock::print::head<weight_t>(p, 40);
   std::cout << "GPU Elapsed Time : " << gpu_elapsed << " (ms)" << std::endl;
 }
 

--- a/examples/sssp/sssp.cu
+++ b/examples/sssp/sssp.cu
@@ -71,20 +71,11 @@ void test_sssp(int num_arguments, char** argument_array) {
   // --
   // Log + Validate
 
-  std::cout << "GPU Distances (output) = ";
-  thrust::copy(distances.begin(),
-               (distances.size() < 40) ? distances.begin() + distances.size()
-                                       : distances.begin() + 40,
-               std::ostream_iterator<weight_t>(std::cout, " "));
-  std::cout << std::endl;
+  std::cout << "GPU distances[:40] = ";
+  gunrock::print::head<weight_t>(distances, 40);
 
   std::cout << "CPU Distances (output) = ";
-  thrust::copy(h_distances.begin(),
-               (h_distances.size() < 40)
-                   ? h_distances.begin() + h_distances.size()
-                   : h_distances.begin() + 40,
-               std::ostream_iterator<weight_t>(std::cout, " "));
-  std::cout << std::endl;
+  gunrock::print::head<weight_t>(h_distances, 40);
 
   std::cout << "GPU Elapsed Time : " << gpu_elapsed << " (ms)" << std::endl;
   std::cout << "CPU Elapsed Time : " << cpu_elapsed << " (ms)" << std::endl;

--- a/include/gunrock/applications/application.hxx
+++ b/include/gunrock/applications/application.hxx
@@ -19,6 +19,7 @@
 
 // Utility includes
 #include <gunrock/util/math.hxx>
+#include <gunrock/util/print.hxx>
 
 // Format includes
 #include <gunrock/formats/formats.hxx>

--- a/include/gunrock/util/print.hxx
+++ b/include/gunrock/util/print.hxx
@@ -1,0 +1,30 @@
+/**
+ * @file print.hxx
+ *
+ * @brief
+ */
+
+#pragma once
+
+namespace gunrock {
+
+/**
+ * @namespace print
+ * Print utilities.
+ */
+namespace print {
+
+// Print the first k elements of a `thrust` vector
+template <typename val_t, typename vec_t>
+void head(vec_t& x, int k) {
+  thrust::copy(
+    x.begin(),
+    (x.size() < k) ? x.begin() + x.size() : x.begin() + k,
+    std::ostream_iterator<val_t>(std::cout, " ")
+  );
+  std::cout << std::endl;
+}
+
+
+}  // namespace print
+}  // namespace gunrock


### PR DESCRIPTION
We often want to print some of the results of an algorithm, but don't want to print values for millions of vertices. 

This commit 
 - adds a `gunrock::print::head(x, k)` function that prints the first `k` elements of a thrust vector `x`.
 - changes `examples/*` that were using ugly code to use this helper.