### PR TITLE
[BUGFIX] Order of values passed to `csc.set`

### DIFF
--- a/include/gunrock/graph/csc.hxx
+++ b/include/gunrock/graph/csc.hxx
@@ -94,8 +94,8 @@ class graph_csc_t {
   //  protected:
   __host__ __device__ void set(vertex_type const& _number_of_vertices,
                                edge_type const& _number_of_edges,
-                               edge_type* Ap,
                                vertex_type* Aj,
+                               edge_type* Ap,
                                weight_type* Ax) {
     this->number_of_vertices = _number_of_vertices;
     this->number_of_edges = _number_of_edges;


### PR DESCRIPTION
Order of values passed to `csc.set` is incorrect.  

More descriptive names than `Aj`, `Ap`, `Ax` might be helpful here.  

Likewise, more descriptive names thatn `Ap`, `J`, `X`, `I` and `Aj` would be helpful in `graph/build/detail.hxx`.  Any reason not to use the following?
```
row_offsets
column_indices
nonzero_values
row_indices
column_offsets
```

Or ... in my opinion even better because they're shorter, the same length 😄 and `nonzero_values` is redundant:
```
row_offsets
col_indices
values
row_indices
col_offsets
```