### PR TITLE
Improve sssp_cpu performance

### DIFF
--- a/examples/sssp/sssp_cpu.hxx
+++ b/examples/sssp/sssp_cpu.hxx
@@ -28,7 +28,7 @@ float run(csr_t& csr,
   thrust::host_vector<weight_t> _nonzero_values(csr.nonzero_values);
   
   edge_t* row_offsets = _row_offsets.data();
-  edge_t* column_indices = _column_indices.data();
+  vertex_t* column_indices = _column_indices.data();
   weight_t* nonzero_values = _nonzero_values.data();
 
   for (vertex_t i = 0; i < csr.number_of_rows; i++)

--- a/examples/sssp/sssp_cpu.hxx
+++ b/examples/sssp/sssp_cpu.hxx
@@ -22,9 +22,14 @@ float run(csr_t& csr,
           vertex_t& single_source,
           weight_t* distances,
           vertex_t* predecessors) {
-  thrust::host_vector<edge_t> row_offsets(csr.row_offsets);  // Copy data to CPU
-  thrust::host_vector<vertex_t> column_indices(csr.column_indices);
-  thrust::host_vector<weight_t> nonzero_values(csr.nonzero_values);
+   
+  thrust::host_vector<edge_t> _row_offsets(csr.row_offsets);  // Copy data to CPU
+  thrust::host_vector<vertex_t> _column_indices(csr.column_indices);
+  thrust::host_vector<weight_t> _nonzero_values(csr.nonzero_values);
+  
+  edge_t* row_offsets = _row_offsets.data();
+  edge_t* column_indices = _column_indices.data();
+  weight_t* nonzero_values = _nonzero_values.data();
 
   for (vertex_t i = 0; i < csr.number_of_rows; i++)
     distances[i] = std::numeric_limits<weight_t>::max();


### PR DESCRIPTION
Unwrapping `thrust` pointers for `sssp_cpu` gives a speedup.

For example -- for rmat20, runtime goes from 4.1 seconds to 1.2 seconds.