### PR TITLE
Move default fetch dir to _cmake_fetch.

### DIFF
--- a/cmake/FetchModernGPU.cmake
+++ b/cmake/FetchModernGPU.cmake
@@ -1,10 +1,17 @@
 include(FetchContent)
+
+
+set(FETCHCONTENT_QUIET off)
+get_filename_component(fc_base "../_cmake_fetch"
+                REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+set(FETCHCONTENT_BASE_DIR ${fc_base})
+
+set(FETCHCONTENT_QUIET off)
 FetchContent_Declare(
     moderngpu
     GIT_REPOSITORY https://github.com/moderngpu/moderngpu.git
     # tag at master branch:
     GIT_TAG        2b3985541c8e88a133769598c406c33ddde9d0a5
-    
 )
 
 FetchContent_GetProperties(moderngpu)

--- a/cmake/FetchRapidJSON.cmake
+++ b/cmake/FetchRapidJSON.cmake
@@ -1,4 +1,10 @@
 include(FetchContent)
+
+set(FETCHCONTENT_QUIET off)
+get_filename_component(fc_base "../_cmake_fetch"
+                REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+set(FETCHCONTENT_BASE_DIR ${fc_base})
+
 FetchContent_Declare(
     rapidjson
     GIT_REPOSITORY https://github.com/Tencent/rapidjson.git

--- a/cmake/FetchThrustCUB.cmake
+++ b/cmake/FetchThrustCUB.cmake
@@ -1,4 +1,11 @@
 include(FetchContent)
+
+
+set(FETCHCONTENT_QUIET off)
+get_filename_component(fc_base "../_cmake_fetch"
+                REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+set(FETCHCONTENT_BASE_DIR ${fc_base})
+
 FetchContent_Declare(
     thrust
     GIT_REPOSITORY https://github.com/thrust/thrust.git


### PR DESCRIPTION
1 )Turn on the fetch message
2 )Move the default FetchContent directory to TopLevel/_cmake_fetch. So that no need to refetching after delete the build directory.