### PR TITLE
Move common member into base and modify launch function

### DIFF
--- a/include/gunrock/cuda/detail/launch_box.hxx
+++ b/include/gunrock/cuda/detail/launch_box.hxx
@@ -72,7 +72,8 @@ struct raise_not_found_error_t {
  * was inspired by this Stack Overflow solution:
  * https://stackoverflow.com/a/67155114/13232647.
  *
- * @tparam lp_v Pack of `launch_params_t` types for each desired arch.
+ * @tparam lp_v Pack of `launch_params_t` types for each corresponding
+ * architecture(s).
  */
 template <typename... lp_v>
 using match_launch_params_t = decltype(std::tuple_cat(

--- a/include/gunrock/cuda/detail/launch_box.hxx
+++ b/include/gunrock/cuda/detail/launch_box.hxx
@@ -22,13 +22,12 @@ namespace detail {
  * @brief Abstract base class for launch parameters.
  *
  * @tparam sm_flags_ Bitwise flags indicating SM versions (`sm_flag_t` enum).
+ * @tparam shared_memory_bytes_ Number of bytes of shared memory to allocate.
  */
-template <sm_flag_t sm_flags_>
+template <sm_flag_t sm_flags_, size_t shared_memory_bytes_>
 struct launch_params_base_t {
-  enum : unsigned { sm_flags = sm_flags_ };
-
- protected:
-  launch_params_base_t() {}
+  static constexpr sm_flag_t sm_flags = sm_flags_;
+  static constexpr size_t shared_memory_bytes = shared_memory_bytes_;
 };
 
 /**

--- a/include/gunrock/cuda/launch_box.hxx
+++ b/include/gunrock/cuda/launch_box.hxx
@@ -65,48 +65,6 @@ struct dim3_t {
 };
 
 /**
- * @brief Collection of kernel launch parameters for different architectures.
- *
- * @par Overview
- * A launch box is a collection of sets of CUDA kernel launch parameters each
- * corresponding to one or more SM architectures. At compile time, the launch
- * box's type resolves to the **first** launch parameters type (derived from
- * `launch_param_base_t`) that match the SM architecture that Gunrock is being
- * compiled for. If there isn't an explicit match, launch parameters for any SM
- * version can be specified at the end of the parameter pack using the
- * `fallback` enum for the `sm_flag_t` template parameter (note that this will
- * invalidate any launch parameter types later in the parameter pack). In the
- * case that there isn't a fallback and the compiler can't find launch
- * parameters for the architecture being compiled for, a static assert will be
- * raised. All launch parameters *should* use the same struct template so there
- * isn't any ambiguity as to what the launch box's constructor is, though this
- * isn't enforced.
- *
- * @par Example
- * The following code is an example of how to instantiate a launch box.
- *
- * \code
- * typedef launch_box_t<
- *     launch_params_t<sm_86 | sm_80, dim3_t<16, 2, 2>, dim3_t<64, 1, 4>, 2>,
- *     launch_params_t<sm_75 | sm_70, dim3_t<32, 2, 4>, dim3_t<64, 8, 8>>,
- *     launch_params_t<sm_61 | sm_60, dim3_t<8, 4, 4>, dim3_t<32, 1, 4>, 2>,
- *     launch_params_t<sm_35, dim3_t<64>, dim3_t<64>, 16>,
- *     launch_params_t<fallback, dim3_t<16>, dim3_t<2>, 4>>
- *     launch_t;
- *
- * launch_t my_launch_box(context);
- * \endcode
- *
- * @tparam lp_v Pack of `launch_params_t` types for each corresponding
- * architecture(s).
- */
-template <typename... lp_v>
-using launch_box_t = std::conditional_t<
-    (std::tuple_size<detail::match_launch_params_t<lp_v...>>::value == 0),
-    detail::raise_not_found_error_t<void>,  // Couldn't find params for SM ver
-    std::tuple_element_t<0, detail::match_launch_params_t<lp_v...>>>;
-
-/**
  * @brief Set of launch parameters for a CUDA kernel.
  *
  * @tparam sm_flags_ Bit flags for the SM architectures the launch parameters
@@ -129,41 +87,6 @@ struct launch_params_t
       block_dimensions_t::dimensions();
   static constexpr dimensions_t grid_dimensions =
       grid_dimensions_t::dimensions();
-
-  /**
-   * @brief Launch a kernel within the given launch box.
-   *
-   * @par Overview
-   * This function is a reimplementation of `std::apply`, that allows for
-   * launching cuda kernels with launch param members of the class and a context
-   * argument. It follows the "possible implementation" of `std::apply` in the
-   * C++ reference: https://en.cppreference.com/w/cpp/utility/apply.
-   *
-   * @tparam func_t The type of the kernel function being passed in.
-   * @tparam args_tuple_t The type of the tuple of arguments being passed in.
-   * @param __ Kernel function to call.
-   * @param args Tuple of arguments to be expanded as the arguments of the
-   * kernel function.
-   * @param context Reference to the context used to launch the kernel (used for
-   * the context's stream).
-   */
-  template <typename func_t, typename args_tuple_t>
-  void launch(func_t&& __, args_tuple_t&& args, standard_context_t& context) {
-    expand_launch(
-        std::forward<func_t>(__), std::forward<args_tuple_t>(args), context,
-        std::make_index_sequence<
-            std::tuple_size_v<std::remove_reference_t<args_tuple_t>>>{});
-  }
-
- private:
-  template <typename func_t, typename args_tuple_t, std::size_t... I>
-  void expand_launch(func_t&& __,
-                     args_tuple_t&& args,
-                     standard_context_t& context,
-                     std::index_sequence<I...>) {
-    __<<<grid_dimensions, block_dimensions, base_t::shared_memory_bytes,
-         context.stream()>>>(std::get<I>(std::forward<args_tuple_t>(args))...);
-  }
 };
 
 /**
@@ -192,27 +115,83 @@ struct launch_params_dynamic_grid_t
     grid_dimensions = dimensions_t(
         (num_elements + block_dimensions.x - 1) / block_dimensions.x, 1, 1);
   }
+};
+
+/**
+ * @brief Alias a selected a launch params type from valid options on
+ * architecture being compiled for.
+ *
+ * @tparam lp_v
+ */
+template <typename... lp_v>
+using select_launch_params_t = std::conditional_t<
+    (std::tuple_size<detail::match_launch_params_t<lp_v...>>::value == 0),
+    detail::raise_not_found_error_t<void>,  // Couldn't find arch params
+    std::tuple_element_t<0, detail::match_launch_params_t<lp_v...>>>;
+
+/**
+ * @brief Collection of kernel launch parameters for different
+ * architectures.
+ *
+ * @par Overview
+ * A launch box is a collection of sets of CUDA kernel launch parameters
+ * each corresponding to one or more SM architectures. At compile time, the
+ * launch box's type resolves to the **first** launch parameters type
+ * (derived from `launch_param_base_t`) that match the SM architecture that
+ * Gunrock is being compiled for. If there isn't an explicit match, launch
+ * parameters for any SM version can be specified at the end of the
+ * parameter pack using the `fallback` enum for the `sm_flag_t` template
+ * parameter (note that this will invalidate any launch parameter types
+ * later in the parameter pack). In the case that there isn't a fallback and
+ * the compiler can't find launch parameters for the architecture being
+ * compiled for, a static assert will be raised. All launch parameters
+ * *should* use the same struct template so there isn't any ambiguity as to
+ * what the launch box's constructor is, though this isn't enforced.
+ *
+ * @par Example
+ * The following code is an example of how to instantiate a launch box.
+ *
+ * \code
+ * typedef launch_box_t<
+ *     launch_params_t<sm_86 | sm_80, dim3_t<16, 2, 2>, dim3_t<64, 1, 4>,
+ * 2>, launch_params_t<sm_75 | sm_70, dim3_t<32, 2, 4>, dim3_t<64, 8, 8>>,
+ *     launch_params_t<sm_61 | sm_60, dim3_t<8, 4, 4>, dim3_t<32, 1, 4>, 2>,
+ *     launch_params_t<sm_35, dim3_t<64>, dim3_t<64>, 16>,
+ *     launch_params_t<fallback, dim3_t<16>, dim3_t<2>, 4>>
+ *     launch_t;
+ *
+ * launch_t my_launch_box(context);
+ * \endcode
+ *
+ * @tparam lp_v Pack of `launch_params_t` types for each corresponding
+ * architecture(s).
+ */
+template <typename... lp_v>
+struct launch_box_t : select_launch_params_t<lp_v...> {
+  typedef select_launch_params_t<lp_v...> base_t;
 
   /**
    * @brief Launch a kernel within the given launch box.
    *
    * @par Overview
-   * This function is a reimplementation of `std::apply`, that allows for
-   * launching cuda kernels with launch param members of the class and a context
-   * argument. It follows the "possible implementation" of `std::apply` in the
-   * C++ reference: https://en.cppreference.com/w/cpp/utility/apply.
+   * This function is a reimplementation of `std::apply`, that allows
+   * for launching cuda kernels with launch param members of the class
+   * and a context argument. It follows the "possible implementation" of
+   * `std::apply` in the C++ reference:
+   * https://en.cppreference.com/w/cpp/utility/apply.
    *
    * @tparam func_t The type of the kernel function being passed in.
-   * @tparam args_tuple_t The type of the tuple of arguments being passed in.
+   * @tparam args_tuple_t The type of the tuple of arguments being
+   * passed in.
    * @param __ Kernel function to call.
-   * @param args Tuple of arguments to be expanded as the arguments of the
-   * kernel function.
-   * @param context Reference to the context used to launch the kernel (used for
-   * the context's stream).
+   * @param args Tuple of arguments to be expanded as the arguments of
+   * the kernel function.
+   * @param context Reference to the context used to launch the kernel
+   * (used for the context's stream).
    */
   template <typename func_t, typename args_tuple_t>
   void launch(func_t&& __, args_tuple_t&& args, standard_context_t& context) {
-    expand_launch(
+    launch_impl(
         std::forward<func_t>(__), std::forward<args_tuple_t>(args), context,
         std::make_index_sequence<
             std::tuple_size_v<std::remove_reference_t<args_tuple_t>>>{});
@@ -220,12 +199,13 @@ struct launch_params_dynamic_grid_t
 
  private:
   template <typename func_t, typename args_tuple_t, std::size_t... I>
-  void expand_launch(func_t&& __,
-                     args_tuple_t&& args,
-                     standard_context_t& context,
-                     std::index_sequence<I...>) {
-    __<<<grid_dimensions, block_dimensions, base_t::shared_memory_bytes,
-         context.stream()>>>(std::get<I>(std::forward<args_tuple_t>(args))...);
+  void launch_impl(func_t&& __,
+                   args_tuple_t&& args,
+                   standard_context_t& context,
+                   std::index_sequence<I...>) {
+    __<<<base_t::grid_dimensions, base_t::block_dimensions,
+         base_t::shared_memory_bytes, context.stream()>>>(
+        std::get<I>(std::forward<args_tuple_t>(args))...);
   }
 };
 
@@ -254,6 +234,5 @@ inline float occupancy(func_t kernel) {
 }
 
 }  // namespace launch_box
-
 }  // namespace cuda
 }  // namespace gunrock

--- a/include/gunrock/cuda/launch_box.hxx
+++ b/include/gunrock/cuda/launch_box.hxx
@@ -50,7 +50,7 @@ struct dimensions_t {
  * @brief CUDA dim3 template representation, since dim3 cannot be used as a
  * template argument.
  *
- * @tparam x_ Dimension in the X direction.
+ * @tparam x_ (default = `1`) Dimension in the X direction.
  * @tparam y_ (default = `1`) Dimension in the Y direction.
  * @tparam z_ (default = `1`) Dimension in the Z direction.
  */
@@ -71,7 +71,8 @@ struct dim3_t {
  * correspond to.
  * @tparam block_dimensions_ A `dim3_t` type representing the block dimensions.
  * @tparam grid_dimensions_ A `dim3_t` type representing the grid dimensions.
- * @tparam shared_memory_bytes_ Number of bytes of shared memory to allocate.
+ * @tparam shared_memory_bytes_ (default = `0`) Number of bytes of shared memory
+ * to allocate.
  */
 template <sm_flag_t sm_flags_,
           typename block_dimensions_,
@@ -96,7 +97,8 @@ struct launch_params_t
  * @tparam sm_flags_ Bit flags for the SM architectures the launch parameters
  * correspond to.
  * @tparam block_dimensions_ A `dim3_t` type representing the block dimensions.
- * @tparam shared_memory_bytes_ Number of bytes of shared memory to allocate.
+ * @tparam shared_memory_bytes_ (default = `0`) Number of bytes of shared memory
+ * to allocate.
  */
 template <sm_flag_t sm_flags_,
           typename block_dimensions_,
@@ -121,7 +123,8 @@ struct launch_params_dynamic_grid_t
  * @brief Alias a selected a launch params type from valid options on
  * architecture being compiled for.
  *
- * @tparam lp_v
+ * @tparam lp_v Pack of `launch_params_t` types for each corresponding
+ * architecture(s).
  */
 template <typename... lp_v>
 using select_launch_params_t = std::conditional_t<
@@ -146,15 +149,15 @@ using select_launch_params_t = std::conditional_t<
  * the compiler can't find launch parameters for the architecture being
  * compiled for, a static assert will be raised. All launch parameters
  * *should* use the same struct template so there isn't any ambiguity as to
- * what the launch box's constructor is, though this isn't enforced.
+ * what the type the launch box is inheriting, though this isn't enforced.
  *
  * @par Example
  * The following code is an example of how to instantiate a launch box.
  *
  * \code
  * typedef launch_box_t<
- *     launch_params_t<sm_86 | sm_80, dim3_t<16, 2, 2>, dim3_t<64, 1, 4>,
- * 2>, launch_params_t<sm_75 | sm_70, dim3_t<32, 2, 4>, dim3_t<64, 8, 8>>,
+ *     launch_params_t<sm_86 | sm_80, dim3_t<16, 2, 2>, dim3_t<4, 1, 4>, 2>,
+ *     launch_params_t<sm_75 | sm_70, dim3_t<32, 2, 4>, dim3_t<64, 8, 8>>,
  *     launch_params_t<sm_61 | sm_60, dim3_t<8, 4, 4>, dim3_t<32, 1, 4>, 2>,
  *     launch_params_t<sm_35, dim3_t<64>, dim3_t<64>, 16>,
  *     launch_params_t<fallback, dim3_t<16>, dim3_t<2>, 4>>
@@ -188,6 +191,7 @@ struct launch_box_t : select_launch_params_t<lp_v...> {
    * the kernel function.
    * @param context Reference to the context used to launch the kernel
    * (used for the context's stream).
+   * \return void
    */
   template <typename func_t, typename args_tuple_t>
   void launch(func_t&& __, args_tuple_t&& args, standard_context_t& context) {
@@ -213,6 +217,7 @@ struct launch_box_t : select_launch_params_t<lp_v...> {
  * @brief Calculator for ratio of active to maximum warps per multiprocessor.
  *
  * @tparam launch_box_t Launch box for the corresponding kernel.
+ * @tparam func_t The type of the kernel function being passed in.
  * @param kernel CUDA kernel for which to calculate the occupancy.
  * \return float
  */

--- a/include/gunrock/framework/operators/advance/block_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/block_mapped.hxx
@@ -184,7 +184,7 @@ void execute(graph_t& G,
   using launch_t =
       launch_box_t<launch_params_dynamic_grid_t<fallback, dim3_t<128>>>;
 
-  launch_t launch_box(context);
+  launch_t launch_box;
 
   launch_box.calculate_grid_dimensions(num_elements);
   auto __bm = block_mapped_kernel<        // kernel
@@ -196,8 +196,9 @@ void execute(graph_t& G,
       typename work_tiles_t::value_type,  // segments value type
       operator_t                          // lambda type
       >;
-  launch_box.launch(__bm, G, op, input->data(), output->data(), num_elements,
-                    segments.data().get());
+  auto __args = std::make_tuple(G, op, input->data(), output->data(),
+                                num_elements, segments.data().get());
+  launch_box.launch(__bm, __args, context);
   context.synchronize();
 }
 

--- a/include/gunrock/framework/operators/advance/thread_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/thread_mapped.hxx
@@ -102,10 +102,11 @@ void execute(graph_t& G,
   using launch_t =
       launch_box_t<launch_params_dynamic_grid_t<fallback, dim3_t<128>>>;
 
-  launch_t launch_box(context);
+  launch_t launch_box;
   launch_box.calculate_grid_dimensions(num_elements);
   auto __tm = thread_mapped_kernel<decltype(neighbors_expand)>;
-  launch_box.launch(__tm, neighbors_expand, num_elements);
+  launch_box.launch(__tm, std::make_tuple(neighbors_expand, num_elements),
+                    context);
   context.synchronize();
 }
 }  // namespace thread_mapped


### PR DESCRIPTION
I made a few changes
1. Move common members into the `launch_param_base_t` class (`shared_memory_bytes`).
2. Remove context as a member and instead use it as an argument of the `launch` function. This makes sense because we might want to use multiple contexts with the same launch box, and rather that re-instantiating a new launch box for each context, we can use the same object.
3. Changed the `launch` function to use a tuple of args rather than a variadic pack of args. This design choice is based around my expectation that most kernels will have a lot of arguments, and it will look cleaner if they are wrapped into a tuple. If this wasn't for launching cuda kernels I would have been able to use `std::apply` in C++17, but I had to reimplement it to be able to use the chevrons `<<<>>>`.

The only issue I have still that I'd like to discuss here is how to efficiently declare the launch functions. Currently across the two types of launch boxes the functions are exact copies from one another. The only difference between the classes is that the functions reference member types that are declared in those classes, so they cannot easily be moved into the shared parent class.