### PR TITLE
Advance Improvements, Frontier resizing, and more...

### DIFF
--- a/examples/experiments/CMakeLists.txt
+++ b/examples/experiments/CMakeLists.txt
@@ -6,6 +6,7 @@ set(EXPERIMENTS_SOURCES
   diamond.cu
   shared_ptr.cu
   templated.cu
+  spmm.cu
 )
 
 get_target_property(ESSENTIALS_ARCHITECTURES essentials CUDA_ARCHITECTURES)

--- a/examples/experiments/spmm.cu
+++ b/examples/experiments/spmm.cu
@@ -1,0 +1,217 @@
+/**
+ * @file spmm.cu
+ * @author Muhammad Osama (mosama@ucdavis.edu)
+ * @brief Sparse matrix-matrix multiplication
+ * @version 0.1
+ * @date 2022-01-20
+ *
+ * @copyright Copyright (c) 2022
+ *
+ */
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include <gunrock/formats/formats.hxx>
+#include <gunrock/io/matrix_market.hxx>
+#include <gunrock/algorithms/generate/random.hxx>
+#include <gunrock/util/print.hxx>
+#include <gunrock/util/timer.hxx>
+#include <gunrock/util/compare.hxx>
+#include <gunrock/util/load_store.hxx>
+
+using namespace gunrock;
+
+enum access_mode_t { row_major, col_major };
+
+template <typename type_t, access_mode_t mode = row_major>
+struct matrix_t {
+  __host__ __device__ constexpr matrix_t()
+      : height(0), width(0), data(nullptr) {}
+  __host__ __device__ constexpr matrix_t(std::size_t _height,
+                                         std::size_t _width,
+                                         type_t* _data)
+      : height(_height), width(_width), data(_data) {}
+
+  __host__ __device__ constexpr matrix_t(const matrix_t& other)
+      : height(other.height), width(other.width), data(other.data) {}
+
+  __host__ __device__ __forceinline__ constexpr std::size_t size() const
+      noexcept {
+    return height * width;
+  }
+
+  __host__ __device__ __forceinline__ constexpr type_t& operator()(
+      std::size_t row,
+      std::size_t col) noexcept {
+    // return data[mode == row_major ? row * width + col : row + col * height];
+    return data[row * width + col];
+  }
+
+  __host__ __device__ __forceinline__ constexpr const type_t& operator()(
+      std::size_t row,
+      std::size_t col) const noexcept {
+    return data[row * width + col];
+  }
+
+  void print() {
+    thrust::device_vector<type_t> d_data(data, data + size());
+    thrust::host_vector<type_t> h_data = d_data;
+
+    std::cout << "Matrix: " << height << " x " << width << std::endl;
+    std::cout << "==========================" << std::endl;
+    for (std::size_t row = 0; row < height; ++row) {
+      for (std::size_t col = 0; col < width; ++col) {
+        std::cout << h_data[row * width + col] << "\t";
+      }
+      std::cout << std::endl;
+    }
+    std::cout << "==========================" << std::endl;
+  }
+
+  std::size_t height;
+  std::size_t width;
+  type_t* data;
+};
+
+template <typename type_t, typename offset_t, typename index_t>
+void cpu_spmm(std::size_t const m,
+              std::size_t const n,
+              std::size_t const nnz,
+              const offset_t* offsets,
+              const index_t* indices,
+              const type_t* values,
+              matrix_t<type_t> const B,
+              matrix_t<type_t> C) {
+  for (index_t row = 0; row < m; ++row) {
+    for (index_t col = 0; col < n; ++col) {
+      type_t sum = 0.0f;
+      for (auto nz = offsets[row]; nz < offsets[row + 1]; ++nz) {
+        sum += values[nz] * B(indices[nz], col);
+      }
+      C(row, col) = sum;
+    }
+  }
+}
+
+template <std::size_t ATOM_X = 1,
+          std::size_t ATOM_Y = 1,
+          std::size_t TILE_X = 16,
+          std::size_t TILE_Y = 16,
+          typename type_t,
+          typename offset_t,
+          typename index_t>
+__global__ void spmm(std::size_t nnz,
+                     offset_t* offsets,
+                     index_t* indices,
+                     type_t* values,
+                     matrix_t<type_t> const B,
+                     matrix_t<type_t> C) {
+  //   constexpr std::size_t ATOM_SIZE = ATOM_X * ATOM_Y;
+  constexpr std::size_t TILE_SIZE = TILE_X * TILE_Y;
+  __shared__ offset_t sh_offsets[TILE_SIZE + 1];
+
+  // For all rows of sparse-matrix A.
+  for (index_t row = threadIdx.x + (blockIdx.x * blockDim.x); row < C.height;
+       row += blockDim.x * gridDim.x) {
+    // Load the row offsets of A into shared memory.
+    sh_offsets[threadIdx.x] = offsets[row];
+    if (threadIdx.x == (blockDim.x - 1) || row == (C.height - 1)) {
+      sh_offsets[threadIdx.x + 1] = offsets[row + 1];
+    }
+    __syncthreads();
+
+    offset_t offset = sh_offsets[threadIdx.x];
+    offset_t end = sh_offsets[threadIdx.x + 1];
+
+    // For all columns of sparse-matrix B.
+    for (index_t col = 0; col < C.width; ++col) {
+      type_t sum = 0.0f;
+      for (offset_t nz = offset; nz < end; ++nz) {
+        index_t k = thread::load(&indices[nz]);
+        type_t val = thread::load(&values[nz]);
+        type_t b_val = B(k, col);
+        sum += val * b_val;
+      }
+      thread::store(&C(row, col), sum);
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  using type_t = float;
+  using vertex_t = int;
+  using edge_t = int;
+  using weight_t = type_t;
+
+  using namespace gunrock;
+  using namespace memory;
+  using namespace format;
+
+  std::string filename = argv[1];
+
+  io::matrix_market_t<vertex_t, edge_t, weight_t> mm;
+  csr_t<memory_space_t::device, vertex_t, edge_t, weight_t> A;
+  A.from_coo(mm.load(filename));
+
+  std::size_t m = A.number_of_rows;
+  std::size_t k = A.number_of_columns;
+  std::size_t n = 4;
+  std::size_t nnz = A.number_of_nonzeros;
+
+  thrust::device_vector<type_t> B_vec(k * n);
+  thrust::device_vector<type_t> C_vec(m * n);
+
+  generate::random::uniform_distribution(B_vec, 1.0f, 2.0f);
+
+  matrix_t<type_t> B(k, n, B_vec.data().get());
+  matrix_t<type_t> C(m, n, C_vec.data().get());
+
+  constexpr std::size_t BLK_X = 16;
+  constexpr std::size_t BLK_Y = 16;
+  constexpr std::size_t num_threads = BLK_X * BLK_Y;
+  std::size_t num_blocks = (m + num_threads - 1) / num_threads;
+
+  util::timer_t timer;
+  timer.start();
+  spmm<<<num_blocks, num_threads>>>(nnz, A.row_offsets.data().get(),
+                                    A.column_indices.data().get(),
+                                    A.nonzero_values.data().get(), B, C);
+  cudaDeviceSynchronize();
+  auto gpu_elapsed = timer.end();
+
+  std::cout << "GPU Elapsed (ms): " << gpu_elapsed << std::endl;
+
+  csr_t<memory_space_t::host, vertex_t, edge_t, weight_t> A_host(A);
+  thrust::host_vector<type_t> B_host_vec = B_vec;
+  thrust::host_vector<type_t> C_host_vec(m * n);
+
+  matrix_t<type_t> B_host(k, n, B_host_vec.data());
+  matrix_t<type_t> C_host(m, n, C_host_vec.data());
+
+  auto start = std::chrono::high_resolution_clock::now();
+  cpu_spmm(m, n, nnz,                     // Sizes
+           A_host.row_offsets.data(),     // A offsets
+           A_host.column_indices.data(),  // A indices
+           A_host.nonzero_values.data(),  // A non-zero values
+           B_host,                        // B tensor
+           C_host                         // C tensor
+  );
+  auto end = std::chrono::high_resolution_clock::now();
+  auto elapsed =
+      std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+          .count();
+
+  std::cout << "CPU Elapsed (ms): " << (float)(elapsed / 1000) << std::endl;
+
+  int n_errors = util::compare(
+      C_vec.data().get(), C_host_vec.data(), m * n,
+      [](const weight_t a, const weight_t b) { return std::abs(a - b) > 1e-6; },
+      true);
+
+  std::cout << "Number of errors: " << n_errors << std::endl;
+}

--- a/include/gunrock/algorithms/algorithms.hxx
+++ b/include/gunrock/algorithms/algorithms.hxx
@@ -30,6 +30,7 @@ namespace gunrock {}  // namespace gunrock
 
 // I/O includes
 #include <gunrock/io/matrix_market.hxx>
+#include <gunrock/io/sample.hxx>
 
 // Graph includes
 #include <gunrock/graph/graph.hxx>

--- a/include/gunrock/algorithms/bfs.hxx
+++ b/include/gunrock/algorithms/bfs.hxx
@@ -95,6 +95,10 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
                       edge_t const& edge,        // edge
                       weight_t const& weight     // weight (tuple).
                       ) -> bool {
+      // If the neighbor is not visited, update the distance. Returning false
+      // here means that the neighbor is not added to the output frontier, and
+      // instead an invalid vertex is added in its place. These invalides (-1 in
+      // most cases) can be removed using a filter operator or uniquify.
       if (distances[neighbor] != std::numeric_limits<vertex_t>::max())
         return false;
       else
@@ -103,24 +107,41 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
                     iteration + 1) == std::numeric_limits<vertex_t>::max());
     };
 
-    auto remove_visited =
+    auto remove_invalids =
         [] __host__ __device__(vertex_t const& vertex) -> bool {
-      // default: always filters out the invalids, keep the rest.
+      // Returning true here means that we keep all the valid vertices.
+      // Internally, filter will automatically remove invalids and will never
+      // pass them to this lambda function.
       return true;
     };
 
     // Execute advance operator on the provided lambda
-    operators::advance::execute<operators::load_balance_t::merge_path>(
+    operators::advance::execute<operators::load_balance_t::block_mapped>(
         G, E, search, context);
 
-    // TODO: This can be replaced with a uniquify call instead.
-    // Execute filter operator on the provided lambda
-    operators::filter::execute<operators::filter_algorithm_t::compact>(
-        G, E, remove_visited, context);
+    // Execute filter operator to remove the invalids.
+    // @todo: Add CLI option to enable or disable this.
+    // operators::filter::execute<operators::filter_algorithm_t::compact>(
+    // G, E, remove_invalids, context);
   }
 
 };  // struct enactor_t
 
+/**
+ * @brief Run Breadth-First Search algorithm on a given graph, G, starting from
+ * the source node, single_source. The resulting distances are stored in the
+ * distances pointer. All data must be allocated by the user, on the device
+ * (GPU) and passed in to this function.
+ *
+ * @tparam graph_t Graph type.
+ * @param G Graph object.
+ * @param single_source A vertex in the graph (integral type).
+ * @param distances Pointer to the distances array of size number of vertices.
+ * @param predecessors Pointer to the predecessors array of size number of
+ * vertices. (optional, wip)
+ * @param context Device context.
+ * @return float Time taken to run the algorithm.
+ */
 template <typename graph_t>
 float run(graph_t& G,
           typename graph_t::vertex_type& single_source,  // Parameter
@@ -130,16 +151,13 @@ float run(graph_t& G,
               std::shared_ptr<cuda::multi_context_t>(
                   new cuda::multi_context_t(0))  // Context
 ) {
-  // <user-defined>
   using vertex_t = typename graph_t::vertex_type;
   using param_type = param_t<vertex_t>;
   using result_type = result_t<vertex_t>;
 
   param_type param(single_source);
   result_type result(distances, predecessors);
-  // </user-defined>
 
-  // <boiler-plate>
   using problem_type = problem_t<graph_t, param_type, result_type>;
   using enactor_type = enactor_t<problem_type>;
 
@@ -149,7 +167,6 @@ float run(graph_t& G,
 
   enactor_type enactor(&problem, context);
   return enactor.enact();
-  // </boiler-plate>
 }
 
 }  // namespace bfs

--- a/include/gunrock/algorithms/bfs.hxx
+++ b/include/gunrock/algorithms/bfs.hxx
@@ -113,6 +113,7 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
     operators::advance::execute<operators::load_balance_t::merge_path>(
         G, E, search, context);
 
+    // TODO: This can be replaced with a uniquify call instead.
     // Execute filter operator on the provided lambda
     operators::filter::execute<operators::filter_algorithm_t::compact>(
         G, E, remove_visited, context);

--- a/include/gunrock/algorithms/spmv.hxx
+++ b/include/gunrock/algorithms/spmv.hxx
@@ -118,8 +118,12 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
       return weight * thread::load(&x[neighbor]);
     };
 
-    // Perform neighbor-reduce
-    operators::neighborreduce::execute(G, E, y, spmv, context);
+    // Perform neighbor-reduce with plus arithmetic operator.
+    auto plus_t = [] __host__ __device__(weight_t a, weight_t b) {
+      return a + b;
+    };
+    operators::neighborreduce::execute(G, E, y, spmv, plus_t, weight_t(0),
+                                       context);
   }
 
   virtual bool is_converged(cuda::multi_context_t& context) {

--- a/include/gunrock/algorithms/sssp.hxx
+++ b/include/gunrock/algorithms/sssp.hxx
@@ -136,7 +136,7 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
     };
 
     // Execute advance operator on the provided lambda
-    operators::advance::execute<operators::load_balance_t::thread_mapped>(
+    operators::advance::execute<operators::load_balance_t::block_mapped>(
         G, E, shortest_path, context);
 
     // Execute filter operator on the provided lambda

--- a/include/gunrock/cuda/detail/launch_box.hxx
+++ b/include/gunrock/cuda/detail/launch_box.hxx
@@ -84,6 +84,17 @@ using match_launch_params_t = decltype(std::tuple_cat(
                                     std::tuple<lp_v>,
                                     std::tuple<>>>()...));
 
+inline void for_each_argument_address(void**) {}
+
+template <typename arg_t, typename... args_t>
+inline void for_each_argument_address(void** collected_addresses,
+                                      arg_t&& arg,
+                                      args_t&&... args) {
+  collected_addresses[0] = const_cast<void*>(static_cast<const void*>(&arg));
+  for_each_argument_address(collected_addresses + 1,
+                            ::std::forward<args_t>(args)...);
+}
+
 }  // namespace detail
 }  // namespace launch_box
 }  // namespace cuda

--- a/include/gunrock/framework/enactor.hxx
+++ b/include/gunrock/framework/enactor.hxx
@@ -169,7 +169,7 @@ struct enactor_t {
         inactive_frontier(reinterpret_cast<frontier_t*>(&frontiers[1])),
         buffer_selector(0),
         iteration(0),
-        scanned_work_domain(problem->get_graph().get_number_of_vertices()) {
+        scanned_work_domain(problem->get_graph().get_number_of_vertices() + 1) {
     /*!
      * If the self manage frontiers property is false, the enactor interface
      * will resize the frontier buffers ahead of time to avoid the first

--- a/include/gunrock/framework/enactor.hxx
+++ b/include/gunrock/framework/enactor.hxx
@@ -33,7 +33,7 @@ struct enactor_properties_t {
    * Resizes the frontier by this factor * the size required.
    * @code frontier.resize(frontier_sizing_factor * new_size);
    */
-  float frontier_sizing_factor{2};
+  float frontier_sizing_factor{1.5f};
 
   /*!
    * Number of frontier buffers to manage.

--- a/include/gunrock/framework/frontier/frontier.hxx
+++ b/include/gunrock/framework/frontier/frontier.hxx
@@ -41,6 +41,9 @@ class frontier_t : public frontier::vector_frontier_t<vertex_t, edge_t, _kind> {
   using type_t = std::conditional_t<_kind == frontier_kind_t::vertex_frontier,
                                     vertex_t,
                                     edge_t>;
+  using offset_t = std::conditional_t<_kind == frontier_kind_t::vertex_frontier,
+                                      edge_t,
+                                      vertex_t>;
   using frontier_type = frontier_t<vertex_t, edge_t, _kind, _view>;
 
   /// TODO: This is a more permenant solution.
@@ -114,7 +117,8 @@ class frontier_t : public frontier::vector_frontier_t<vertex_t, edge_t, _kind> {
    * @brief Get the number of elements within the frontier.
    * @return std::size_t
    */
-  std::size_t get_number_of_elements(cuda::stream_t stream = 0) {
+  __host__ __device__ __forceinline__ std::size_t get_number_of_elements(
+      cuda::stream_t stream = 0) {
     return underlying_view_t::get_number_of_elements(stream);
   }
 

--- a/include/gunrock/framework/frontier/vector_frontier.hxx
+++ b/include/gunrock/framework/frontier/vector_frontier.hxx
@@ -76,7 +76,8 @@ class vector_frontier_t {
    * @brief Get the number of elements within the frontier.
    * @return std::size_t
    */
-  std::size_t get_number_of_elements(cuda::stream_t stream = 0) const {
+  __host__ __device__ __forceinline__ std::size_t get_number_of_elements(
+      cuda::stream_t stream = 0) const {
     return num_elements;
   }
 
@@ -117,8 +118,8 @@ class vector_frontier_t {
    */
   __device__ __forceinline__ constexpr void set_element_at(
       type_t const& element,
-      std::size_t const& idx) const
-      noexcept {  /// XXX: This should not be const
+      std::size_t const& idx)
+      const noexcept {  /// XXX: This should not be const
     thread::store(this->get() + idx, element);
   }
 

--- a/include/gunrock/framework/frontier/vector_frontier.hxx
+++ b/include/gunrock/framework/frontier/vector_frontier.hxx
@@ -36,7 +36,8 @@ class vector_frontier_t {
   /**
    * @brief Default constructor.
    */
-  vector_frontier_t() : num_elements(0), raw_ptr(nullptr), resizing_factor(1) {
+  vector_frontier_t()
+      : num_elements(0), raw_ptr(nullptr), resizing_factor(1.0f) {
     /// TODO: we are using a vector of size 1 to avoid the overhead of setting
     /// it up later. Check if this is valid to do.
     p_storage = std::make_shared<vector_t<type_t, memory_space_t::device>>(
@@ -50,7 +51,7 @@ class vector_frontier_t {
    * @param size
    * @param frontier_resizing_factor
    */
-  vector_frontier_t(std::size_t size, float frontier_resizing_factor = 1.0)
+  vector_frontier_t(std::size_t size, float frontier_resizing_factor = 1.0f)
       : num_elements(size), resizing_factor(frontier_resizing_factor) {
     p_storage = std::make_shared<vector_t<type_t, memory_space_t::device>>(
         vector_t<type_t, memory_space_t::device>(size));
@@ -223,7 +224,9 @@ class vector_frontier_t {
    *
    * @param size size to reserve (size is in count not bytes).
    */
-  void reserve(std::size_t const& size) { p_storage.get()->reserve(size); }
+  void reserve(std::size_t const& size) {
+    p_storage.get()->reserve(size * resizing_factor);
+  }
 
   /**
    * @brief Parallel sort the frontier.

--- a/include/gunrock/framework/operators/advance/advance.hxx
+++ b/include/gunrock/framework/operators/advance/advance.hxx
@@ -19,6 +19,7 @@
 
 #include <gunrock/framework/operators/advance/helpers.hxx>
 #include <gunrock/framework/operators/advance/merge_path.hxx>
+#include <gunrock/framework/operators/advance/merge_path_v2.hxx>
 #include <gunrock/framework/operators/advance/thread_mapped.hxx>
 #include <gunrock/framework/operators/advance/block_mapped.hxx>
 #include <gunrock/framework/operators/advance/bucketing.hxx>
@@ -107,6 +108,9 @@ void execute(graph_t& G,
     if (lb == load_balance_t::merge_path) {
       merge_path::execute<direction, input_type, output_type>(
           G, op, input, output, segments, *context0);
+    } else if (lb == load_balance_t::merge_path_v2) {
+      merge_path_v2::execute<direction, input_type, output_type>(
+          G, op, *input, *output, segments, *context0);
     } else if (lb == load_balance_t::thread_mapped) {
       thread_mapped::execute<direction, input_type, output_type>(
           G, op, *input, *output, segments, *context0);

--- a/include/gunrock/framework/operators/advance/advance.hxx
+++ b/include/gunrock/framework/operators/advance/advance.hxx
@@ -102,9 +102,6 @@ void execute(graph_t& G,
   if (context.size() == 1) {
     auto context0 = context.get_context(0);
 
-    // std::cout << "[ADV] Input:: ";
-    // input->print();
-
     if (lb == load_balance_t::merge_path) {
       merge_path::execute<direction, input_type, output_type>(
           G, op, input, output, segments, *context0);
@@ -116,14 +113,11 @@ void execute(graph_t& G,
           G, op, *input, *output, segments, *context0);
     } else if (lb == load_balance_t::block_mapped) {
       block_mapped::execute<direction, input_type, output_type>(
-          G, op, input, output, segments, *context0);
+          G, op, *input, *output, *context0);
     } else {
       error::throw_if_exception(cudaErrorUnknown,
                                 "Advance type not supported.");
     }
-
-    // std::cout << "[ADV] Output:: ";
-    // output->print();
 
   } else {
     error::throw_if_exception(cudaErrorUnknown,

--- a/include/gunrock/framework/operators/advance/block_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/block_mapped.hxx
@@ -22,6 +22,8 @@
 #include <cub/block/block_load.cuh>
 #include <cub/block/block_scan.cuh>
 
+#include <cooperative_groups.h>
+
 namespace gunrock {
 namespace operators {
 namespace advance {
@@ -33,14 +35,14 @@ template <unsigned int THREADS_PER_BLOCK,
           advance_io_type_t output_type,
           typename graph_t,
           typename frontier_t,
-          typename work_tiles_t,
+          typename offset_counter_t,
           typename operator_t>
 void __global__ block_mapped_kernel(graph_t const G,
                                     operator_t op,
                                     frontier_t* input,
                                     frontier_t* output,
                                     std::size_t input_size,
-                                    work_tiles_t* offsets) {
+                                    offset_counter_t* block_offsets) {
   using vertex_t = typename graph_t::vertex_type;
   using edge_t = typename graph_t::edge_type;
 
@@ -49,21 +51,16 @@ void __global__ block_mapped_kernel(graph_t const G,
 
   // Specialize Block Scan for 1D block of THREADS_PER_BLOCK.
   using block_scan_t = cub::BlockScan<edge_t, THREADS_PER_BLOCK>;
-  // using block_load_t =
-  //     cub::BlockLoad<edge_t, THREADS_PER_BLOCK, ITEMS_PER_THREAD>;
 
   auto global_idx = cuda::thread::global::id::x();
   auto local_idx = cuda::thread::local::id::x();
 
+  ///
   thrust::counting_iterator<type_t> all_vertices(0);
+  __shared__ typename block_scan_t::TempStorage scan;
+  __shared__ offset_counter_t offset[1];
 
-  __shared__ union TempStorage {
-    typename block_scan_t::TempStorage scan;
-    // typename block_load_t::TempStorage load;
-  } storage;
-
-  // Prepare data to process (to shmem/registers).
-  __shared__ vertex_t offset[1];
+  /// 1. Load input data to shared/register memory.
   __shared__ vertex_t vertices[THREADS_PER_BLOCK];
   __shared__ edge_t degrees[THREADS_PER_BLOCK];
   __shared__ edge_t sedges[THREADS_PER_BLOCK];
@@ -86,33 +83,43 @@ void __global__ block_mapped_kernel(graph_t const G,
   }
   __syncthreads();
 
-  // Exclusive sum of degrees.
+  /// 2. Exclusive sum of degrees to find total work items per block.
   edge_t aggregate_degree_per_block;
-  block_scan_t(storage.scan)
-      .ExclusiveSum(th_deg, th_deg, aggregate_degree_per_block);
+  block_scan_t(scan).ExclusiveSum(th_deg, th_deg, aggregate_degree_per_block);
   __syncthreads();
 
-  // Store back to shared memory.
+  // Store back to shared memory (to later use in the binary search).
   degrees[local_idx] = th_deg[0];
 
+  /// 3. Compute block offsets if there's an output frontier.
   if (output_type != advance_io_type_t::none) {
-    // Accumulate the output size to global memory, only done once per block.
+    // Accumulate the output size to global memory, only done once per block by
+    // threadIdx.x == 0, and retrieve the previously stored value from the
+    // global memory. The previous value is now current block's starting offset.
+    // All writes from this block will be after this offset. Note: this does not
+    // guarantee that the data written will be in any specific order.
     if (local_idx == 0)
+      offset[0] = math::atomic::add(
+          &block_offsets[0], (offset_counter_t)aggregate_degree_per_block);
+
+    // Old method reads from precomputed segments instead of the atomic add
+    // above.
+    /* if (local_idx == 0)
       if ((cuda::block::id::x() * cuda::block::size::x()) < input_size)
-        offset[0] = offsets[cuda::block::id::x() * cuda::block::size::x()];
+        offset[0] = segments[cuda::block::id::x() * cuda::block::size::x()]; */
   }
 
-  __syncthreads();
-
-  // To search for which vertex id we are computing on.
   auto length = global_idx - local_idx + cuda::block::size::x();
 
-  // Bound check.
   if (input_size < length)
     length = input_size;
 
   length -= global_idx - local_idx;
 
+  /// 4. Compute. Using binary search, find the source vertex each thread is
+  /// processing, and the corresponding edge, neighbor and weight tuple. Passed
+  /// to the user-defined lambda operator to process. If there's an output, the
+  /// resultant neighbor or invalid vertex is written to the output frontier.
   for (edge_t i = local_idx;            // threadIdx.x
        i < aggregate_degree_per_block;  // total degree to process
        i += cuda::block::size::x()      // increment by blockDim.x
@@ -139,11 +146,13 @@ void __global__ block_mapped_kernel(graph_t const G,
     bool cond = op(v, n, e, w);
 
     // Store [neighbor] into the output frontier.
-    if (output_type != advance_io_type_t::none)
+    if (output_type != advance_io_type_t::none) {
+      __syncthreads();
       output[offset[0] + i] =
           (cond && n != v) ? n : gunrock::numeric_limits<vertex_t>::invalid();
+    }
   }
-}  // namespace block_mapped
+}
 
 template <advance_direction_t direction,
           advance_io_type_t input_type,
@@ -159,8 +168,7 @@ void execute(graph_t& G,
              work_tiles_t& segments,
              cuda::standard_context_t& context) {
   if constexpr (output_type != advance_io_type_t::none) {
-    // This shouldn't be required for block-mapped.
-    auto size_of_output = compute_output_length(G, input, segments, context);
+    auto size_of_output = compute_output_length(G, *input, context);
 
     // If output frontier is empty, resize and return.
     if (size_of_output <= 0) {
@@ -196,9 +204,11 @@ void execute(graph_t& G,
       typename work_tiles_t::value_type,  // segments value type
       operator_t                          // lambda type
       >;
-  auto __args = std::make_tuple(G, op, input->data(), output->data(),
-                                num_elements, segments.data().get());
-  launch_box.launch(__bm, __args, context);
+
+  thrust::device_vector<typename work_tiles_t::value_type> block_offsets(1);
+  launch_box.calculate_grid_dimensions_strided(num_elements);
+  launch_box.launch(context, __bm, G, op, input->data(), output->data(),
+                    num_elements, block_offsets.data().get());
   context.synchronize();
 }
 

--- a/include/gunrock/framework/operators/advance/block_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/block_mapped.hxx
@@ -90,7 +90,7 @@ __global__ void __launch_bounds__(THREADS_PER_BLOCK, 2)
   degrees[local_idx] = th_deg[0];
 
   /// 3. Compute block offsets if there's an output frontier.
-  if (output_type != advance_io_type_t::none) {
+  if constexpr (output_type != advance_io_type_t::none) {
     // Accumulate the output size to global memory, only done once per block by
     // threadIdx.x == 0, and retrieve the previously stored value from the
     // global memory. The previous value is now current block's starting offset.
@@ -139,7 +139,7 @@ __global__ void __launch_bounds__(THREADS_PER_BLOCK, 2)
     bool cond = op(v, n, e, w);
 
     // Store [neighbor] into the output frontier.
-    if (output_type != advance_io_type_t::none) {
+    if constexpr (output_type != advance_io_type_t::none) {
       output[offset[0] + i] =
           (cond && n != v) ? n : gunrock::numeric_limits<vertex_t>::invalid();
     }

--- a/include/gunrock/framework/operators/advance/helpers.hxx
+++ b/include/gunrock/framework/operators/advance/helpers.hxx
@@ -1,7 +1,8 @@
 /**
  * @file helpers.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)
- * @brief
+ * @brief Helper functions for Advance operators.
+ * @todo These can be potentially moved under frontier's API.
  * @version 0.1
  * @date 2021-01-12
  *

--- a/include/gunrock/framework/operators/advance/helpers.hxx
+++ b/include/gunrock/framework/operators/advance/helpers.hxx
@@ -19,6 +19,21 @@ namespace gunrock {
 namespace operators {
 namespace advance {
 
+/**
+ * @brief Given a frontier and a graph, find the offsets segments for the output
+ * frontier of an advance operation (@see advance.hxx).
+ *
+ * @tparam graph_t Graph type
+ * @tparam frontier_t Frontier type
+ * @tparam work_tiles_t Segments type
+ * @param G Graph
+ * @param input Input frontier
+ * @param segments Segments array
+ * @param context CUDA context
+ * @param graph_as_frontier if true, entire graph is used instead of the
+ * frontier.
+ * @return std::size_t number of total elements in the output frontier.
+ */
 template <typename graph_t, typename frontier_t, typename work_tiles_t>
 std::size_t compute_output_offsets(graph_t& G,
                                    frontier_t* input,
@@ -76,17 +91,23 @@ std::size_t compute_output_offsets(graph_t& G,
       segments.data() + location_of_total_scanned_items,
       segments.data() + location_of_total_scanned_items + 1);
 
-  // DEBUG::
-  // std::cout << "Scanned Segments (THRUST) = ";
-  // thrust::copy(segments.begin(), segments.end(),
-  //              std::ostream_iterator<edge_t>(std::cout, " "));
-  // std::cout << std::endl;
-  // std::cout << "Size of Output (THRUST) = " << size_of_output[0] <<
-  // std::endl;
-
   return size_of_output[0];
 }
 
+/**
+ * @brief Cheaper than compute_output_offsets, only calculates the number of
+ * total elements in the output frontier. Maybe used to allocate the output
+ * frontier.
+ *
+ * @tparam graph_t Graph type
+ * @tparam frontier_t Frontier type
+ * @param G Graph object
+ * @param input Input frontier
+ * @param context CUDA context
+ * @param graph_as_frontier if true, entire graph is used instead of the
+ * frontier.
+ * @return std::size_t number of total elements in the output frontier
+ */
 template <typename graph_t, typename frontier_t>
 std::size_t compute_output_length(graph_t& G,
                                   frontier_t& input,

--- a/include/gunrock/framework/operators/advance/merge_path.hxx
+++ b/include/gunrock/framework/operators/advance/merge_path.hxx
@@ -60,7 +60,7 @@ void execute(graph_t& G,
                                     typename graph_t::graph_csr_view_t,
                                     typename graph_t::graph_csc_view_t>;
 
-  auto size_of_output = compute_output_length(
+  auto size_of_output = compute_output_offsets(
       G, input, segments, context,
       (input_type == advance_io_type_t::graph) ? true : false);
 

--- a/include/gunrock/framework/operators/advance/merge_path_v2.hxx
+++ b/include/gunrock/framework/operators/advance/merge_path_v2.hxx
@@ -1,0 +1,235 @@
+/**
+ * @file merge_path_v2.hxx
+ * @author Muhammad Osama (mosama@ucdavis.edu)
+ * @brief
+ * @version 0.1
+ * @date 2022-01-22
+ *
+ * @copyright Copyright (c) 2022
+ *
+ */
+
+#pragma once
+
+#include <gunrock/util/math.hxx>
+#include <gunrock/cuda/context.hxx>
+
+#include <gunrock/framework/operators/configs.hxx>
+
+#include <thrust/binary_search.h>
+#include <thrust/iterator/counting_iterator.h>
+
+namespace gunrock {
+namespace operators {
+namespace advance {
+namespace merge_path_v2 {
+
+template <typename index_t>
+struct coordinate_t {
+  index_t x, y;
+};
+
+namespace search {
+/**
+ * @brief Thrust based 2D binary-search.
+ *
+ */
+template <typename offset_t, typename a_iterator_t, typename b_iterator_t>
+__host__ __device__ __forceinline__ void merge_path(
+    const offset_t diagonal,
+    const a_iterator_t a,
+    const b_iterator_t b,
+    const offset_t a_len,
+    const offset_t b_len,
+    coordinate_t<offset_t>& coordinate) {
+  // Diagonal search range (in x-coordinate space)
+  offset_t x_min = max(diagonal - b_len, 0);
+  offset_t x_max = min(diagonal, a_len);
+
+  auto it = thrust::lower_bound(
+      thrust::seq,                                 // Sequential impl
+      thrust::counting_iterator<offset_t>(x_min),  // Start iterator @ x_min
+      thrust::counting_iterator<offset_t>(x_max),  // End   iterator @ x_max
+      diagonal,                                    // ...
+      [=] __host__ __device__(const offset_t& idx, const offset_t& diagonal) {
+        return a[idx] <= b[diagonal - idx - 1];
+      });
+
+  coordinate.x = min(*it, a_len);
+  coordinate.y = diagonal - *it;
+}
+}  // namespace search
+
+template <std::size_t items_per_thread,
+          std::size_t num_threads,
+          std::size_t merge_tile_size,
+          advance_io_type_t input_type,
+          advance_io_type_t output_type,
+          typename graph_t,
+          typename operator_t,
+          typename frontier_t,
+          typename work_tiles_t>
+__global__ void merge_path_v2_kernel(graph_t G,
+                                     operator_t op,
+                                     frontier_t input,
+                                     frontier_t output,
+                                     work_tiles_t* segments,
+                                     std::size_t num_merge_tiles) {
+  using type_t = typename frontier_t::type_t;
+  using offset_t = typename frontier_t::offset_t;
+
+  __shared__ coordinate_t<type_t> tile_coords[2];
+  __shared__ offset_t
+      _tile_row_end_offsets[items_per_thread + merge_tile_size + 1];
+
+  auto elements = (input_type == advance_io_type_t::graph)
+                      ? G.get_number_of_vertices()
+                      : input.get_number_of_elements();
+
+  auto atoms = (input_type == advance_io_type_t::graph)
+                   ? G.get_number_of_edges()
+                   : output.get_number_of_elements();
+
+  auto row_end_offsets = (input_type == advance_io_type_t::graph)
+                             ? G.get_row_offsets() + 1
+                             : segments + 1;
+
+  int tile_idx = blockIdx.x * gridDim.y + blockIdx.y;  // Tile Index
+  if (tile_idx >= num_merge_tiles)
+    return;
+
+  /// For each block, generate the starting and ending coordinates of a tile.
+  /// This corresponds to the starting and ending vertices and the edges.
+  if (threadIdx.x < 2) {
+    coordinate_t<offset_t> coords;
+    offset_t diagonal = (tile_idx + threadIdx.x) * merge_tile_size;
+    thrust::counting_iterator<offset_t> indices(0);
+
+    search::merge_path((offset_t)diagonal,  // diagonal
+                       row_end_offsets,     // list A
+                       indices,             // list B
+                       (offset_t)elements,  // input elements
+                       (offset_t)atoms,     // work items
+                       coords               // coordinates
+    );
+
+    tile_coords[threadIdx.x] = coords;
+  }
+  __syncthreads();
+
+  coordinate_t<type_t> tile_idx_start = tile_coords[0];
+  coordinate_t<type_t> tile_idx_end = tile_coords[1];
+
+  // Consume Tile
+  type_t tile_num_rows = tile_idx_end.x - tile_idx_start.x;
+  type_t tile_num_nonzeros = tile_idx_end.y - tile_idx_start.y;
+
+// Gather the row end-offsets for the merge tile into shared memory
+#pragma unroll 1
+  for (int item = threadIdx.x; item < tile_num_rows + items_per_thread;
+       item += num_threads) {
+    const offset_t offset =
+        min((offset_t)(tile_idx_start.x + item), (offset_t)(elements - 1));
+    _tile_row_end_offsets[item] = row_end_offsets[offset];
+  }
+
+  __syncthreads();
+
+  // Identify starting and ending diagonals and find starting and ending
+  // Merge-Path coordinates (row-idx, nonzero-idx) for each thread.
+  thrust::counting_iterator<offset_t> tile_nonzeros(
+      tile_idx_start.y);  // Per Thread Merge
+                          // list B: Non-zero indices (ℕ)
+  coordinate_t<offset_t> thread_idx_start;
+
+  search::merge_path((offset_t)(threadIdx.x * items_per_thread),  // Diagonal
+                     _tile_row_end_offsets,             // List A: SHMEM
+                     tile_nonzeros,                     // List B
+                     tile_num_rows, tile_num_nonzeros,  // NZR, NNZ
+                     thread_idx_start                   // Output: Coords
+  );
+  __syncthreads();
+
+  // reset back to initial M,NZ indices for the new column
+  auto source = thread_idx_start.x;
+  auto nz_idx = thread_idx_start.y;
+
+#pragma unroll
+  for (int ITEM = 0; ITEM < items_per_thread; ++ITEM) {
+    offset_t edge = min((offset_t)tile_nonzeros[nz_idx], (offset_t)(atoms - 1));
+    auto row_end_offset = _tile_row_end_offsets[source];
+    auto neighbor = G.get_destination_vertex(edge);
+    auto weight = G.get_edge_weight(edge);
+
+    if (tile_nonzeros[nz_idx] < row_end_offset) {
+      // Move down (accumulate)
+      bool cond = op(source, neighbor, edge, weight);
+      printf("%d %d (%d, %d) %f\n", (int)source, (int)neighbor, (int)edge,
+             (int)nz_idx, (float)weight);
+
+      if (output_type != advance_io_type_t::none) {
+        // std::size_t out_idx = ;
+        // type_t element = (cond && neighbor != source)
+        //                      ? neighbor
+        //                      : gunrock::numeric_limits<type_t>::invalid();
+        // output.set_element_at(element, out_idx);
+      }
+
+      ++nz_idx;
+    } else {
+      // Move right (reset)
+      ++source;
+    }
+  }
+  //   __syncthreads();
+}
+
+template <advance_direction_t direction,
+          advance_io_type_t input_type,
+          advance_io_type_t output_type,
+          typename graph_t,
+          typename operator_t,
+          typename frontier_t,
+          typename work_tiles_t>
+void execute(graph_t& G,
+             operator_t op,
+             frontier_t& input,
+             frontier_t& output,
+             work_tiles_t& segments,
+             cuda::standard_context_t& context) {
+  auto size_of_output = compute_output_length(
+      G, &input, segments, context,
+      (input_type == advance_io_type_t::graph) ? true : false);
+
+  std::size_t num_elements = (input_type == advance_io_type_t::graph)
+                                 ? G.get_number_of_vertices()
+                                 : input.get_number_of_elements();
+
+  // Kernel configuration.
+  constexpr std::size_t num_threads = 128;
+  constexpr std::size_t items_per_thread = 1;
+
+  // Tile size of merge path.
+  constexpr std::size_t merge_tile_size = num_threads * items_per_thread;
+
+  // Total number of work items to process.
+  std::size_t num_merge_items = num_elements + size_of_output;
+
+  // Number of tiles for the kernel.
+  std::size_t num_merge_tiles =
+      math::divide_round_up(num_merge_items, merge_tile_size);
+
+  dim3 grid(num_merge_tiles, num_merge_tiles, 1);
+
+  // Launch kernel.
+  merge_path_v2_kernel<items_per_thread, num_threads, merge_tile_size,
+                       input_type, output_type>
+      <<<grid, num_threads, 0, context.stream()>>>(
+          G, op, input, output, segments.data().get(), num_merge_tiles);
+
+  context.synchronize();
+}
+}  // namespace merge_path_v2
+}  // namespace advance
+}  // namespace operators
+}  // namespace gunrock

--- a/include/gunrock/framework/operators/advance/merge_path_v2.hxx
+++ b/include/gunrock/framework/operators/advance/merge_path_v2.hxx
@@ -197,7 +197,7 @@ void execute(graph_t& G,
              frontier_t& output,
              work_tiles_t& segments,
              cuda::standard_context_t& context) {
-  auto size_of_output = compute_output_length(
+  auto size_of_output = compute_output_offsets(
       G, &input, segments, context,
       (input_type == advance_io_type_t::graph) ? true : false);
 

--- a/include/gunrock/framework/operators/advance/thread_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/thread_mapped.hxx
@@ -1,7 +1,7 @@
 /**
  * @file thread_mapped.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)
- * @brief
+ * @brief Advance operator where a vertex/edge is mapped to a thread.
  * @version 0.1
  * @date 2020-10-20
  *

--- a/include/gunrock/framework/operators/advance/thread_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/thread_mapped.hxx
@@ -38,7 +38,7 @@ void execute(graph_t& G,
   using type_t = typename frontier_t::type_t;
 
   if (output_type != advance_io_type_t::none) {
-    auto size_of_output = compute_output_length(G, &input, segments, context);
+    auto size_of_output = compute_output_offsets(G, &input, segments, context);
 
     // If output frontier is empty, resize and return.
     if (size_of_output <= 0) {

--- a/include/gunrock/framework/operators/batch/batch.hxx
+++ b/include/gunrock/framework/operators/batch/batch.hxx
@@ -1,7 +1,8 @@
 /**
  * @file batch.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)
- * @brief
+ * @brief A batch operator is an operator that can be used to execute a
+ * function/application in bactches with different inputs using C++ threads.
  * @version 0.1
  * @date 2021-05-04
  *
@@ -22,6 +23,41 @@ namespace gunrock {
 namespace operators {
 namespace batch {
 
+/**
+ * @brief Batch operator takes a function and executes it in parallel till the
+ * desired number of jobs. The function is executed from the CPU using C++
+ * `std::threads`.
+ *
+ * @par Overview
+ * The batch operator takes a function and executes it in parallel for number of
+ * jobs count. This is a very rudimentary implementation of the batch operator,
+ * we can expand this further by calculating the available GPU resources, and
+ * also possibly using this to parallelize the batches onto multiple GPUs.
+ *
+ * @par Example
+ * The following code snippet is a simple snippet on how to use the batch
+ * operator.
+ *
+ * \code {.cpp}
+ * // Lambda function to be executed in separate std::threads.
+ * auto f = [&](std::size_t job_idx) -> float {
+ *   // Function to run in batches, this can be an entire application
+ *   // running on the GPU with different inputs (such as job_idx as a vertex).
+ *   return run_function(G, (vertex_t)job_idx); // ... run another function.
+ * };
+ *
+ * // Execute the batch operator on the provided lambda function.
+ * operators::batch::execute(f, 10, total_elapsed.data());
+ * \endcode
+ *
+ * @tparam function_t The function type.
+ * @tparam args_t type of the arguments to the function.
+ * @param f The function to execute.
+ * @param number_of_jobs Number of jobs to execute.
+ * @param total_elapsed pointer to an array of size 1, that stores the time
+ * taken to execute all the batches.
+ * @param args variadic arguments to be passed to the function (wip).
+ */
 template <typename function_t, typename... args_t>
 void execute(function_t f,
              std::size_t number_of_jobs,

--- a/include/gunrock/framework/operators/configs.hxx
+++ b/include/gunrock/framework/operators/configs.hxx
@@ -33,7 +33,8 @@ enum load_balance_t {
   warp_mapped,    /// (wip) Equal # of elements per warp
   block_mapped,   /// Equal # of elements per block
   bucketing,      /// (wip) Davidson et al. (SSSP)
-  merge_path,     /// Merrill & Garland (SpMV)
+  merge_path,     /// Merrill & Garland (SpMV):: ModernGPU
+  merge_path_v2,  /// Merrill & Garland (SpMV):: CUSTOM
   work_stealing,  /// (wip) <cite>
 };
 

--- a/include/gunrock/framework/operators/filter/filter.hxx
+++ b/include/gunrock/framework/operators/filter/filter.hxx
@@ -16,6 +16,46 @@ namespace gunrock {
 namespace operators {
 namespace filter {
 
+/**
+ * @brief A filter operator generates a new frontier from an input frontier by
+ * removing elements in the frontier that do not satisfy a predicate.
+ *
+ * @par Overview
+ * A frontier consists of vertices or edges, a filter applied to an incoming
+ * frontier will generate a new frontier by removing the elements that do not
+ * satisfy a user-defined predicate. The predicate function takes a vertex or
+ * edge and returns a boolean value. If the boolean value is `true`, the element
+ * is kept in the new frontier. If the boolean value is `false`, the element is
+ * removed from the new frontier.
+ *
+ * @par Example
+ * The following code is a simple snippet on how to use filter operator with
+ * input and output frontiers.
+ *
+ * \code {.cpp}
+ * auto sample = [=] __host__ __device__(
+ *   vertex_t const& vertex) -> bool {
+ *   return (vertex % 2 == 0) ? true : false; // keep even vertices
+ * };
+ *
+ * // Execute filter operator on the provided lambda
+ * operators::filter::execute<operators::filter_algorithm_t::bypass>(
+ *   G, sample, input_frontier, output_frontier, context);
+ * \endcode
+ *
+ *
+ * @tparam alg_type The filter algorithm to use (@see filter_algorithm_t).
+ * @tparam graph_t The graph type.
+ * @tparam operator_t The operator type.
+ * @tparam frontier_t The frontier type.
+ * @param G Input graph used.
+ * @param op Predicate function, can be defined using a C++ lambda function.
+ * @param input Input frontier.
+ * @param output Output frontier (some algorithms may not use this, and allow
+ * for in-place filter operation).
+ * @param context a `cuda::multi_context_t` that contains GPU contexts for the
+ * available CUDA devices. Used to launch the filter kernels.
+ */
 template <filter_algorithm_t alg_type,
           typename graph_t,
           typename operator_t,
@@ -45,6 +85,46 @@ void execute(graph_t& G,
   }
 }
 
+/**
+ * @brief A filter operator generates a new frontier from an input frontier by
+ * removing elements in the frontier that do not satisfy a predicate.
+ *
+ * @par Overview
+ * A frontier consists of vertices or edges, a filter applied to an incoming
+ * frontier will generate a new frontier by removing the elements that do not
+ * satisfy a user-defined predicate. The predicate function takes a vertex or
+ * edge and returns a boolean value. If the boolean value is `true`, the element
+ * is kept in the new frontier. If the boolean value is `false`, the element is
+ * removed from the new frontier.
+ *
+ * @par Example
+ * The following code is a simple snippet on how to use filter within the
+ * enactor loop instead of explicit input and output frontiers. The enactor
+ * interface automatically swap the input and output after each iteration.
+ *
+ * \code {.cpp}
+ * auto sample = [=] __host__ __device__(
+ *   vertex_t const& vertex) -> bool {
+ *   return (vertex % 2 == 0) ? true : false; // keep even vertices
+ * };
+ *
+ * // Execute filter operator on the provided lambda
+ * operators::filter::execute<operators::filter_algorithm_t::bypass>(
+ *   G, E, sample, context);
+ * \endcode
+ *
+ *
+ * @tparam alg_type The filter algorithm to use (@see filter_algorithm_t).
+ * @tparam graph_t The graph type.
+ * @tparam enactor_type The enactor type.
+ * @tparam operator_t The operator type.
+ * @tparam frontier_t The frontier type.
+ * @param G Input graph used.
+ * @param op Predicate function, can be defined using a C++ lambda function.
+ * @param E Enactor struct containing input and output frontiers.
+ * @param context a `cuda::multi_context_t` that contains GPU contexts for the
+ * available CUDA devices. Used to launch the filter kernels.
+ */
 template <filter_algorithm_t alg_type,
           typename graph_t,
           typename enactor_type,

--- a/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
+++ b/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
@@ -23,6 +23,33 @@ namespace gunrock {
 namespace operators {
 namespace neighborreduce {
 
+/**
+ * @brief Neighbor reduce is an operator that performs reduction on the segments
+ * of neighbors (or data associated with the neighbors), where each segment is
+ * defined by the source vertex. Another simple way to understand this operator
+ * is to perform advance and then reduction on the resultant traversal.
+ *
+ * @par Overview
+ * Neighbor reduce operator, built on top of segmented reduction. This is
+ * a very limited approach to neighbor reduce, and only gives you the edge per
+ * advance. It's only implemented on the entire graph (frontiers not yet
+ * supported).
+ *
+ * @tparam input_t advance input type (advance_io_type_t::graph supported)
+ * @tparam graph_t graph type.
+ * @tparam enactor_t enactor type.
+ * @tparam output_t output type.
+ * @tparam operator_t user-defined lambda function.
+ * @tparam arithmetic_t binary function, arithmetic operator such as sum, max,
+ * min, etc.
+ * @param G graph to perform advance-reduce on.
+ * @param E enactor structure (not used as of right now).
+ * @param output output buffer.
+ * @param op user-defined lambda function.
+ * @param arithmetic_op arithmetic operator (binary).
+ * @param init_value initial value for the reduction.
+ * @param context cuda context (@see cuda::multi_context_t).
+ */
 template <advance_io_type_t input_t = advance_io_type_t::graph,
           typename graph_t,
           typename enactor_t,

--- a/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
+++ b/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
@@ -27,22 +27,29 @@ template <advance_io_type_t input_t = advance_io_type_t::graph,
           typename graph_t,
           typename enactor_t,
           typename output_t,
-          typename operator_t>
+          typename operator_t,
+          typename arithmetic_t>
 void execute(graph_t& G,
              enactor_t* E,
              output_t* output,
              operator_t op,
+             arithmetic_t arithmetic_op,
+             output_t init_value,
              cuda::multi_context_t& context) {
   if (context.size() == 1) {
     auto context0 = context.get_context(0);
 
-    // TODO: Expose the binary op and init value.
-    // TODO: Throw an exception if CSR isn't supported.
+    using find_csr_t = typename graph_t::graph_csr_view_t;
+    if (!(G.template contains_representation<find_csr_t>())) {
+      error::throw_if_exception(cudaErrorUnknown,
+                                "CSR sparse-matrix representation "
+                                "required for neighborreduce operator.");
+    }
+
     // TODO: Throw an exception if input_t is not advance_io_type_t::graph.
     mgpu::transform_segreduce(op, G.get_number_of_edges(), G.get_row_offsets(),
-                              G.get_number_of_vertices(), output,
-                              mgpu::plus_t<output_t>(), (output_t)0,
-                              *(context0->mgpu()));
+                              G.get_number_of_vertices(), output, arithmetic_op,
+                              init_value, *(context0->mgpu()));
   }
 }
 

--- a/include/gunrock/util/math.hxx
+++ b/include/gunrock/util/math.hxx
@@ -21,6 +21,12 @@ namespace gunrock {
  */
 namespace math {
 
+template <typename type_t>
+constexpr __host__ __device__ __forceinline__ type_t
+divide_round_up(type_t const& a, type_t const& b) {
+  return (a + b - 1) / b;
+}
+
 /**
  * @brief Statically determine log2(N).
  *


### PR DESCRIPTION
## Enhancements
- [x] `block_mapped`: Performance improvements.
- [x] Tested: Chesapeake, Hollywood, Road_USA, Delaunay.
- [x] SpMM kernel.
- [x] Block-mapped uses one exclusive scan instead of two.
- [x] (wip) merge_path_v2
- [x] Cooperative launch + other launch

## Known Issues
- Infinite loop on `bips`-like datasets using `block_mapped`, possibly due to negative weights?