### PR TITLE
Advance Improvements, Frontier resizing, and more...

### DIFF
--- a/include/gunrock/algorithms/algorithms.hxx
+++ b/include/gunrock/algorithms/algorithms.hxx
@@ -30,6 +30,7 @@ namespace gunrock {}  // namespace gunrock
 
 // I/O includes
 #include <gunrock/io/matrix_market.hxx>
+#include <gunrock/io/sample.hxx>
 
 // Graph includes
 #include <gunrock/graph/graph.hxx>

--- a/include/gunrock/algorithms/bfs.hxx
+++ b/include/gunrock/algorithms/bfs.hxx
@@ -95,6 +95,10 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
                       edge_t const& edge,        // edge
                       weight_t const& weight     // weight (tuple).
                       ) -> bool {
+      // If the neighbor is not visited, update the distance. Returning false
+      // here means that the neighbor is not added to the output frontier, and
+      // instead an invalid vertex is added in its place. These invalides (-1 in
+      // most cases) can be removed using a filter operator or uniquify.
       if (distances[neighbor] != std::numeric_limits<vertex_t>::max())
         return false;
       else
@@ -103,24 +107,41 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
                     iteration + 1) == std::numeric_limits<vertex_t>::max());
     };
 
-    auto remove_visited =
+    auto remove_invalids =
         [] __host__ __device__(vertex_t const& vertex) -> bool {
-      // default: always filters out the invalids, keep the rest.
+      // Returning true here means that we keep all the valid vertices.
+      // Internally, filter will automatically remove invalids and will never
+      // pass them to this lambda function.
       return true;
     };
 
     // Execute advance operator on the provided lambda
-    operators::advance::execute<operators::load_balance_t::merge_path>(
+    operators::advance::execute<operators::load_balance_t::block_mapped>(
         G, E, search, context);
 
-    // TODO: This can be replaced with a uniquify call instead.
-    // Execute filter operator on the provided lambda
-    operators::filter::execute<operators::filter_algorithm_t::compact>(
-        G, E, remove_visited, context);
+    // Execute filter operator to remove the invalids.
+    // @todo: Add CLI option to enable or disable this.
+    // operators::filter::execute<operators::filter_algorithm_t::compact>(
+    // G, E, remove_invalids, context);
   }
 
 };  // struct enactor_t
 
+/**
+ * @brief Run Breadth-First Search algorithm on a given graph, G, starting from
+ * the source node, single_source. The resulting distances are stored in the
+ * distances pointer. All data must be allocated by the user, on the device
+ * (GPU) and passed in to this function.
+ *
+ * @tparam graph_t Graph type.
+ * @param G Graph object.
+ * @param single_source A vertex in the graph (integral type).
+ * @param distances Pointer to the distances array of size number of vertices.
+ * @param predecessors Pointer to the predecessors array of size number of
+ * vertices. (optional, wip)
+ * @param context Device context.
+ * @return float Time taken to run the algorithm.
+ */
 template <typename graph_t>
 float run(graph_t& G,
           typename graph_t::vertex_type& single_source,  // Parameter
@@ -130,16 +151,13 @@ float run(graph_t& G,
               std::shared_ptr<cuda::multi_context_t>(
                   new cuda::multi_context_t(0))  // Context
 ) {
-  // <user-defined>
   using vertex_t = typename graph_t::vertex_type;
   using param_type = param_t<vertex_t>;
   using result_type = result_t<vertex_t>;
 
   param_type param(single_source);
   result_type result(distances, predecessors);
-  // </user-defined>
 
-  // <boiler-plate>
   using problem_type = problem_t<graph_t, param_type, result_type>;
   using enactor_type = enactor_t<problem_type>;
 
@@ -149,7 +167,6 @@ float run(graph_t& G,
 
   enactor_type enactor(&problem, context);
   return enactor.enact();
-  // </boiler-plate>
 }
 
 }  // namespace bfs

--- a/include/gunrock/algorithms/bfs.hxx
+++ b/include/gunrock/algorithms/bfs.hxx
@@ -113,6 +113,7 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
     operators::advance::execute<operators::load_balance_t::merge_path>(
         G, E, search, context);
 
+    // TODO: This can be replaced with a uniquify call instead.
     // Execute filter operator on the provided lambda
     operators::filter::execute<operators::filter_algorithm_t::compact>(
         G, E, remove_visited, context);

--- a/include/gunrock/algorithms/spmv.hxx
+++ b/include/gunrock/algorithms/spmv.hxx
@@ -118,8 +118,12 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
       return weight * thread::load(&x[neighbor]);
     };
 
-    // Perform neighbor-reduce
-    operators::neighborreduce::execute(G, E, y, spmv, context);
+    // Perform neighbor-reduce with plus arithmetic operator.
+    auto plus_t = [] __host__ __device__(weight_t a, weight_t b) {
+      return a + b;
+    };
+    operators::neighborreduce::execute(G, E, y, spmv, plus_t, weight_t(0),
+                                       context);
   }
 
   virtual bool is_converged(cuda::multi_context_t& context) {

--- a/include/gunrock/algorithms/sssp.hxx
+++ b/include/gunrock/algorithms/sssp.hxx
@@ -136,7 +136,7 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
     };
 
     // Execute advance operator on the provided lambda
-    operators::advance::execute<operators::load_balance_t::thread_mapped>(
+    operators::advance::execute<operators::load_balance_t::block_mapped>(
         G, E, shortest_path, context);
 
     // Execute filter operator on the provided lambda

--- a/include/gunrock/cuda/detail/launch_box.hxx
+++ b/include/gunrock/cuda/detail/launch_box.hxx
@@ -84,6 +84,17 @@ using match_launch_params_t = decltype(std::tuple_cat(
                                     std::tuple<lp_v>,
                                     std::tuple<>>>()...));
 
+inline void for_each_argument_address(void**) {}
+
+template <typename arg_t, typename... args_t>
+inline void for_each_argument_address(void** collected_addresses,
+                                      arg_t&& arg,
+                                      args_t&&... args) {
+  collected_addresses[0] = const_cast<void*>(static_cast<const void*>(&arg));
+  for_each_argument_address(collected_addresses + 1,
+                            ::std::forward<args_t>(args)...);
+}
+
 }  // namespace detail
 }  // namespace launch_box
 }  // namespace cuda

--- a/include/gunrock/framework/enactor.hxx
+++ b/include/gunrock/framework/enactor.hxx
@@ -169,7 +169,7 @@ struct enactor_t {
         inactive_frontier(reinterpret_cast<frontier_t*>(&frontiers[1])),
         buffer_selector(0),
         iteration(0),
-        scanned_work_domain(problem->get_graph().get_number_of_vertices()) {
+        scanned_work_domain(problem->get_graph().get_number_of_vertices() + 1) {
     /*!
      * If the self manage frontiers property is false, the enactor interface
      * will resize the frontier buffers ahead of time to avoid the first

--- a/include/gunrock/framework/enactor.hxx
+++ b/include/gunrock/framework/enactor.hxx
@@ -33,7 +33,7 @@ struct enactor_properties_t {
    * Resizes the frontier by this factor * the size required.
    * @code frontier.resize(frontier_sizing_factor * new_size);
    */
-  float frontier_sizing_factor{2};
+  float frontier_sizing_factor{1.5f};
 
   /*!
    * Number of frontier buffers to manage.

--- a/include/gunrock/framework/frontier/vector_frontier.hxx
+++ b/include/gunrock/framework/frontier/vector_frontier.hxx
@@ -36,7 +36,8 @@ class vector_frontier_t {
   /**
    * @brief Default constructor.
    */
-  vector_frontier_t() : num_elements(0), raw_ptr(nullptr), resizing_factor(1) {
+  vector_frontier_t()
+      : num_elements(0), raw_ptr(nullptr), resizing_factor(1.0f) {
     /// TODO: we are using a vector of size 1 to avoid the overhead of setting
     /// it up later. Check if this is valid to do.
     p_storage = std::make_shared<vector_t<type_t, memory_space_t::device>>(
@@ -50,7 +51,7 @@ class vector_frontier_t {
    * @param size
    * @param frontier_resizing_factor
    */
-  vector_frontier_t(std::size_t size, float frontier_resizing_factor = 1.0)
+  vector_frontier_t(std::size_t size, float frontier_resizing_factor = 1.0f)
       : num_elements(size), resizing_factor(frontier_resizing_factor) {
     p_storage = std::make_shared<vector_t<type_t, memory_space_t::device>>(
         vector_t<type_t, memory_space_t::device>(size));
@@ -223,7 +224,9 @@ class vector_frontier_t {
    *
    * @param size size to reserve (size is in count not bytes).
    */
-  void reserve(std::size_t const& size) { p_storage.get()->reserve(size); }
+  void reserve(std::size_t const& size) {
+    p_storage.get()->reserve(size * resizing_factor);
+  }
 
   /**
    * @brief Parallel sort the frontier.

--- a/include/gunrock/framework/operators/advance/advance.hxx
+++ b/include/gunrock/framework/operators/advance/advance.hxx
@@ -102,9 +102,6 @@ void execute(graph_t& G,
   if (context.size() == 1) {
     auto context0 = context.get_context(0);
 
-    // std::cout << "[ADV] Input:: ";
-    // input->print();
-
     if (lb == load_balance_t::merge_path) {
       merge_path::execute<direction, input_type, output_type>(
           G, op, input, output, segments, *context0);
@@ -116,14 +113,11 @@ void execute(graph_t& G,
           G, op, *input, *output, segments, *context0);
     } else if (lb == load_balance_t::block_mapped) {
       block_mapped::execute<direction, input_type, output_type>(
-          G, op, input, output, segments, *context0);
+          G, op, *input, *output, *context0);
     } else {
       error::throw_if_exception(cudaErrorUnknown,
                                 "Advance type not supported.");
     }
-
-    // std::cout << "[ADV] Output:: ";
-    // output->print();
 
   } else {
     error::throw_if_exception(cudaErrorUnknown,

--- a/include/gunrock/framework/operators/advance/block_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/block_mapped.hxx
@@ -22,6 +22,8 @@
 #include <cub/block/block_load.cuh>
 #include <cub/block/block_scan.cuh>
 
+#include <cooperative_groups.h>
+
 namespace gunrock {
 namespace operators {
 namespace advance {
@@ -33,14 +35,14 @@ template <unsigned int THREADS_PER_BLOCK,
           advance_io_type_t output_type,
           typename graph_t,
           typename frontier_t,
-          typename work_tiles_t,
+          typename offset_counter_t,
           typename operator_t>
 void __global__ block_mapped_kernel(graph_t const G,
                                     operator_t op,
                                     frontier_t* input,
                                     frontier_t* output,
                                     std::size_t input_size,
-                                    work_tiles_t* offsets) {
+                                    offset_counter_t* block_offsets) {
   using vertex_t = typename graph_t::vertex_type;
   using edge_t = typename graph_t::edge_type;
 
@@ -49,21 +51,16 @@ void __global__ block_mapped_kernel(graph_t const G,
 
   // Specialize Block Scan for 1D block of THREADS_PER_BLOCK.
   using block_scan_t = cub::BlockScan<edge_t, THREADS_PER_BLOCK>;
-  // using block_load_t =
-  //     cub::BlockLoad<edge_t, THREADS_PER_BLOCK, ITEMS_PER_THREAD>;
 
   auto global_idx = cuda::thread::global::id::x();
   auto local_idx = cuda::thread::local::id::x();
 
+  ///
   thrust::counting_iterator<type_t> all_vertices(0);
+  __shared__ typename block_scan_t::TempStorage scan;
+  __shared__ offset_counter_t offset[1];
 
-  __shared__ union TempStorage {
-    typename block_scan_t::TempStorage scan;
-    // typename block_load_t::TempStorage load;
-  } storage;
-
-  // Prepare data to process (to shmem/registers).
-  __shared__ vertex_t offset[1];
+  /// 1. Load input data to shared/register memory.
   __shared__ vertex_t vertices[THREADS_PER_BLOCK];
   __shared__ edge_t degrees[THREADS_PER_BLOCK];
   __shared__ edge_t sedges[THREADS_PER_BLOCK];
@@ -86,33 +83,43 @@ void __global__ block_mapped_kernel(graph_t const G,
   }
   __syncthreads();
 
-  // Exclusive sum of degrees.
+  /// 2. Exclusive sum of degrees to find total work items per block.
   edge_t aggregate_degree_per_block;
-  block_scan_t(storage.scan)
-      .ExclusiveSum(th_deg, th_deg, aggregate_degree_per_block);
+  block_scan_t(scan).ExclusiveSum(th_deg, th_deg, aggregate_degree_per_block);
   __syncthreads();
 
-  // Store back to shared memory.
+  // Store back to shared memory (to later use in the binary search).
   degrees[local_idx] = th_deg[0];
 
+  /// 3. Compute block offsets if there's an output frontier.
   if (output_type != advance_io_type_t::none) {
-    // Accumulate the output size to global memory, only done once per block.
+    // Accumulate the output size to global memory, only done once per block by
+    // threadIdx.x == 0, and retrieve the previously stored value from the
+    // global memory. The previous value is now current block's starting offset.
+    // All writes from this block will be after this offset. Note: this does not
+    // guarantee that the data written will be in any specific order.
     if (local_idx == 0)
+      offset[0] = math::atomic::add(
+          &block_offsets[0], (offset_counter_t)aggregate_degree_per_block);
+
+    // Old method reads from precomputed segments instead of the atomic add
+    // above.
+    /* if (local_idx == 0)
       if ((cuda::block::id::x() * cuda::block::size::x()) < input_size)
-        offset[0] = offsets[cuda::block::id::x() * cuda::block::size::x()];
+        offset[0] = segments[cuda::block::id::x() * cuda::block::size::x()]; */
   }
 
-  __syncthreads();
-
-  // To search for which vertex id we are computing on.
   auto length = global_idx - local_idx + cuda::block::size::x();
 
-  // Bound check.
   if (input_size < length)
     length = input_size;
 
   length -= global_idx - local_idx;
 
+  /// 4. Compute. Using binary search, find the source vertex each thread is
+  /// processing, and the corresponding edge, neighbor and weight tuple. Passed
+  /// to the user-defined lambda operator to process. If there's an output, the
+  /// resultant neighbor or invalid vertex is written to the output frontier.
   for (edge_t i = local_idx;            // threadIdx.x
        i < aggregate_degree_per_block;  // total degree to process
        i += cuda::block::size::x()      // increment by blockDim.x
@@ -139,11 +146,13 @@ void __global__ block_mapped_kernel(graph_t const G,
     bool cond = op(v, n, e, w);
 
     // Store [neighbor] into the output frontier.
-    if (output_type != advance_io_type_t::none)
+    if (output_type != advance_io_type_t::none) {
+      __syncthreads();
       output[offset[0] + i] =
           (cond && n != v) ? n : gunrock::numeric_limits<vertex_t>::invalid();
+    }
   }
-}  // namespace block_mapped
+}
 
 template <advance_direction_t direction,
           advance_io_type_t input_type,
@@ -159,8 +168,7 @@ void execute(graph_t& G,
              work_tiles_t& segments,
              cuda::standard_context_t& context) {
   if constexpr (output_type != advance_io_type_t::none) {
-    // This shouldn't be required for block-mapped.
-    auto size_of_output = compute_output_length(G, input, segments, context);
+    auto size_of_output = compute_output_length(G, *input, context);
 
     // If output frontier is empty, resize and return.
     if (size_of_output <= 0) {
@@ -196,9 +204,11 @@ void execute(graph_t& G,
       typename work_tiles_t::value_type,  // segments value type
       operator_t                          // lambda type
       >;
-  auto __args = std::make_tuple(G, op, input->data(), output->data(),
-                                num_elements, segments.data().get());
-  launch_box.launch(__bm, __args, context);
+
+  thrust::device_vector<typename work_tiles_t::value_type> block_offsets(1);
+  launch_box.calculate_grid_dimensions_strided(num_elements);
+  launch_box.launch(context, __bm, G, op, input->data(), output->data(),
+                    num_elements, block_offsets.data().get());
   context.synchronize();
 }
 

--- a/include/gunrock/framework/operators/advance/block_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/block_mapped.hxx
@@ -90,7 +90,7 @@ __global__ void __launch_bounds__(THREADS_PER_BLOCK, 2)
   degrees[local_idx] = th_deg[0];
 
   /// 3. Compute block offsets if there's an output frontier.
-  if (output_type != advance_io_type_t::none) {
+  if constexpr (output_type != advance_io_type_t::none) {
     // Accumulate the output size to global memory, only done once per block by
     // threadIdx.x == 0, and retrieve the previously stored value from the
     // global memory. The previous value is now current block's starting offset.
@@ -139,7 +139,7 @@ __global__ void __launch_bounds__(THREADS_PER_BLOCK, 2)
     bool cond = op(v, n, e, w);
 
     // Store [neighbor] into the output frontier.
-    if (output_type != advance_io_type_t::none) {
+    if constexpr (output_type != advance_io_type_t::none) {
       output[offset[0] + i] =
           (cond && n != v) ? n : gunrock::numeric_limits<vertex_t>::invalid();
     }

--- a/include/gunrock/framework/operators/advance/helpers.hxx
+++ b/include/gunrock/framework/operators/advance/helpers.hxx
@@ -1,7 +1,8 @@
 /**
  * @file helpers.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)
- * @brief
+ * @brief Helper functions for Advance operators.
+ * @todo These can be potentially moved under frontier's API.
  * @version 0.1
  * @date 2021-01-12
  *

--- a/include/gunrock/framework/operators/advance/helpers.hxx
+++ b/include/gunrock/framework/operators/advance/helpers.hxx
@@ -19,6 +19,21 @@ namespace gunrock {
 namespace operators {
 namespace advance {
 
+/**
+ * @brief Given a frontier and a graph, find the offsets segments for the output
+ * frontier of an advance operation (@see advance.hxx).
+ *
+ * @tparam graph_t Graph type
+ * @tparam frontier_t Frontier type
+ * @tparam work_tiles_t Segments type
+ * @param G Graph
+ * @param input Input frontier
+ * @param segments Segments array
+ * @param context CUDA context
+ * @param graph_as_frontier if true, entire graph is used instead of the
+ * frontier.
+ * @return std::size_t number of total elements in the output frontier.
+ */
 template <typename graph_t, typename frontier_t, typename work_tiles_t>
 std::size_t compute_output_offsets(graph_t& G,
                                    frontier_t* input,
@@ -76,17 +91,23 @@ std::size_t compute_output_offsets(graph_t& G,
       segments.data() + location_of_total_scanned_items,
       segments.data() + location_of_total_scanned_items + 1);
 
-  // DEBUG::
-  // std::cout << "Scanned Segments (THRUST) = ";
-  // thrust::copy(segments.begin(), segments.end(),
-  //              std::ostream_iterator<edge_t>(std::cout, " "));
-  // std::cout << std::endl;
-  // std::cout << "Size of Output (THRUST) = " << size_of_output[0] <<
-  // std::endl;
-
   return size_of_output[0];
 }
 
+/**
+ * @brief Cheaper than compute_output_offsets, only calculates the number of
+ * total elements in the output frontier. Maybe used to allocate the output
+ * frontier.
+ *
+ * @tparam graph_t Graph type
+ * @tparam frontier_t Frontier type
+ * @param G Graph object
+ * @param input Input frontier
+ * @param context CUDA context
+ * @param graph_as_frontier if true, entire graph is used instead of the
+ * frontier.
+ * @return std::size_t number of total elements in the output frontier
+ */
 template <typename graph_t, typename frontier_t>
 std::size_t compute_output_length(graph_t& G,
                                   frontier_t& input,

--- a/include/gunrock/framework/operators/advance/merge_path.hxx
+++ b/include/gunrock/framework/operators/advance/merge_path.hxx
@@ -60,7 +60,7 @@ void execute(graph_t& G,
                                     typename graph_t::graph_csr_view_t,
                                     typename graph_t::graph_csc_view_t>;
 
-  auto size_of_output = compute_output_length(
+  auto size_of_output = compute_output_offsets(
       G, input, segments, context,
       (input_type == advance_io_type_t::graph) ? true : false);
 

--- a/include/gunrock/framework/operators/advance/merge_path_v2.hxx
+++ b/include/gunrock/framework/operators/advance/merge_path_v2.hxx
@@ -197,7 +197,7 @@ void execute(graph_t& G,
              frontier_t& output,
              work_tiles_t& segments,
              cuda::standard_context_t& context) {
-  auto size_of_output = compute_output_length(
+  auto size_of_output = compute_output_offsets(
       G, &input, segments, context,
       (input_type == advance_io_type_t::graph) ? true : false);
 

--- a/include/gunrock/framework/operators/advance/thread_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/thread_mapped.hxx
@@ -1,7 +1,7 @@
 /**
  * @file thread_mapped.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)
- * @brief
+ * @brief Advance operator where a vertex/edge is mapped to a thread.
  * @version 0.1
  * @date 2020-10-20
  *

--- a/include/gunrock/framework/operators/advance/thread_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/thread_mapped.hxx
@@ -38,7 +38,7 @@ void execute(graph_t& G,
   using type_t = typename frontier_t::type_t;
 
   if (output_type != advance_io_type_t::none) {
-    auto size_of_output = compute_output_length(G, &input, segments, context);
+    auto size_of_output = compute_output_offsets(G, &input, segments, context);
 
     // If output frontier is empty, resize and return.
     if (size_of_output <= 0) {

--- a/include/gunrock/framework/operators/batch/batch.hxx
+++ b/include/gunrock/framework/operators/batch/batch.hxx
@@ -1,7 +1,8 @@
 /**
  * @file batch.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)
- * @brief
+ * @brief A batch operator is an operator that can be used to execute a
+ * function/application in bactches with different inputs using C++ threads.
  * @version 0.1
  * @date 2021-05-04
  *
@@ -22,6 +23,41 @@ namespace gunrock {
 namespace operators {
 namespace batch {
 
+/**
+ * @brief Batch operator takes a function and executes it in parallel till the
+ * desired number of jobs. The function is executed from the CPU using C++
+ * `std::threads`.
+ *
+ * @par Overview
+ * The batch operator takes a function and executes it in parallel for number of
+ * jobs count. This is a very rudimentary implementation of the batch operator,
+ * we can expand this further by calculating the available GPU resources, and
+ * also possibly using this to parallelize the batches onto multiple GPUs.
+ *
+ * @par Example
+ * The following code snippet is a simple snippet on how to use the batch
+ * operator.
+ *
+ * \code {.cpp}
+ * // Lambda function to be executed in separate std::threads.
+ * auto f = [&](std::size_t job_idx) -> float {
+ *   // Function to run in batches, this can be an entire application
+ *   // running on the GPU with different inputs (such as job_idx as a vertex).
+ *   return run_function(G, (vertex_t)job_idx); // ... run another function.
+ * };
+ *
+ * // Execute the batch operator on the provided lambda function.
+ * operators::batch::execute(f, 10, total_elapsed.data());
+ * \endcode
+ *
+ * @tparam function_t The function type.
+ * @tparam args_t type of the arguments to the function.
+ * @param f The function to execute.
+ * @param number_of_jobs Number of jobs to execute.
+ * @param total_elapsed pointer to an array of size 1, that stores the time
+ * taken to execute all the batches.
+ * @param args variadic arguments to be passed to the function (wip).
+ */
 template <typename function_t, typename... args_t>
 void execute(function_t f,
              std::size_t number_of_jobs,

--- a/include/gunrock/framework/operators/filter/filter.hxx
+++ b/include/gunrock/framework/operators/filter/filter.hxx
@@ -16,6 +16,46 @@ namespace gunrock {
 namespace operators {
 namespace filter {
 
+/**
+ * @brief A filter operator generates a new frontier from an input frontier by
+ * removing elements in the frontier that do not satisfy a predicate.
+ *
+ * @par Overview
+ * A frontier consists of vertices or edges, a filter applied to an incoming
+ * frontier will generate a new frontier by removing the elements that do not
+ * satisfy a user-defined predicate. The predicate function takes a vertex or
+ * edge and returns a boolean value. If the boolean value is `true`, the element
+ * is kept in the new frontier. If the boolean value is `false`, the element is
+ * removed from the new frontier.
+ *
+ * @par Example
+ * The following code is a simple snippet on how to use filter operator with
+ * input and output frontiers.
+ *
+ * \code {.cpp}
+ * auto sample = [=] __host__ __device__(
+ *   vertex_t const& vertex) -> bool {
+ *   return (vertex % 2 == 0) ? true : false; // keep even vertices
+ * };
+ *
+ * // Execute filter operator on the provided lambda
+ * operators::filter::execute<operators::filter_algorithm_t::bypass>(
+ *   G, sample, input_frontier, output_frontier, context);
+ * \endcode
+ *
+ *
+ * @tparam alg_type The filter algorithm to use (@see filter_algorithm_t).
+ * @tparam graph_t The graph type.
+ * @tparam operator_t The operator type.
+ * @tparam frontier_t The frontier type.
+ * @param G Input graph used.
+ * @param op Predicate function, can be defined using a C++ lambda function.
+ * @param input Input frontier.
+ * @param output Output frontier (some algorithms may not use this, and allow
+ * for in-place filter operation).
+ * @param context a `cuda::multi_context_t` that contains GPU contexts for the
+ * available CUDA devices. Used to launch the filter kernels.
+ */
 template <filter_algorithm_t alg_type,
           typename graph_t,
           typename operator_t,
@@ -45,6 +85,46 @@ void execute(graph_t& G,
   }
 }
 
+/**
+ * @brief A filter operator generates a new frontier from an input frontier by
+ * removing elements in the frontier that do not satisfy a predicate.
+ *
+ * @par Overview
+ * A frontier consists of vertices or edges, a filter applied to an incoming
+ * frontier will generate a new frontier by removing the elements that do not
+ * satisfy a user-defined predicate. The predicate function takes a vertex or
+ * edge and returns a boolean value. If the boolean value is `true`, the element
+ * is kept in the new frontier. If the boolean value is `false`, the element is
+ * removed from the new frontier.
+ *
+ * @par Example
+ * The following code is a simple snippet on how to use filter within the
+ * enactor loop instead of explicit input and output frontiers. The enactor
+ * interface automatically swap the input and output after each iteration.
+ *
+ * \code {.cpp}
+ * auto sample = [=] __host__ __device__(
+ *   vertex_t const& vertex) -> bool {
+ *   return (vertex % 2 == 0) ? true : false; // keep even vertices
+ * };
+ *
+ * // Execute filter operator on the provided lambda
+ * operators::filter::execute<operators::filter_algorithm_t::bypass>(
+ *   G, E, sample, context);
+ * \endcode
+ *
+ *
+ * @tparam alg_type The filter algorithm to use (@see filter_algorithm_t).
+ * @tparam graph_t The graph type.
+ * @tparam enactor_type The enactor type.
+ * @tparam operator_t The operator type.
+ * @tparam frontier_t The frontier type.
+ * @param G Input graph used.
+ * @param op Predicate function, can be defined using a C++ lambda function.
+ * @param E Enactor struct containing input and output frontiers.
+ * @param context a `cuda::multi_context_t` that contains GPU contexts for the
+ * available CUDA devices. Used to launch the filter kernels.
+ */
 template <filter_algorithm_t alg_type,
           typename graph_t,
           typename enactor_type,

--- a/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
+++ b/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
@@ -23,6 +23,33 @@ namespace gunrock {
 namespace operators {
 namespace neighborreduce {
 
+/**
+ * @brief Neighbor reduce is an operator that performs reduction on the segments
+ * of neighbors (or data associated with the neighbors), where each segment is
+ * defined by the source vertex. Another simple way to understand this operator
+ * is to perform advance and then reduction on the resultant traversal.
+ *
+ * @par Overview
+ * Neighbor reduce operator, built on top of segmented reduction. This is
+ * a very limited approach to neighbor reduce, and only gives you the edge per
+ * advance. It's only implemented on the entire graph (frontiers not yet
+ * supported).
+ *
+ * @tparam input_t advance input type (advance_io_type_t::graph supported)
+ * @tparam graph_t graph type.
+ * @tparam enactor_t enactor type.
+ * @tparam output_t output type.
+ * @tparam operator_t user-defined lambda function.
+ * @tparam arithmetic_t binary function, arithmetic operator such as sum, max,
+ * min, etc.
+ * @param G graph to perform advance-reduce on.
+ * @param E enactor structure (not used as of right now).
+ * @param output output buffer.
+ * @param op user-defined lambda function.
+ * @param arithmetic_op arithmetic operator (binary).
+ * @param init_value initial value for the reduction.
+ * @param context cuda context (@see cuda::multi_context_t).
+ */
 template <advance_io_type_t input_t = advance_io_type_t::graph,
           typename graph_t,
           typename enactor_t,

--- a/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
+++ b/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
@@ -27,22 +27,29 @@ template <advance_io_type_t input_t = advance_io_type_t::graph,
           typename graph_t,
           typename enactor_t,
           typename output_t,
-          typename operator_t>
+          typename operator_t,
+          typename arithmetic_t>
 void execute(graph_t& G,
              enactor_t* E,
              output_t* output,
              operator_t op,
+             arithmetic_t arithmetic_op,
+             output_t init_value,
              cuda::multi_context_t& context) {
   if (context.size() == 1) {
     auto context0 = context.get_context(0);
 
-    // TODO: Expose the binary op and init value.
-    // TODO: Throw an exception if CSR isn't supported.
+    using find_csr_t = typename graph_t::graph_csr_view_t;
+    if (!(G.template contains_representation<find_csr_t>())) {
+      error::throw_if_exception(cudaErrorUnknown,
+                                "CSR sparse-matrix representation "
+                                "required for neighborreduce operator.");
+    }
+
     // TODO: Throw an exception if input_t is not advance_io_type_t::graph.
     mgpu::transform_segreduce(op, G.get_number_of_edges(), G.get_row_offsets(),
-                              G.get_number_of_vertices(), output,
-                              mgpu::plus_t<output_t>(), (output_t)0,
-                              *(context0->mgpu()));
+                              G.get_number_of_vertices(), output, arithmetic_op,
+                              init_value, *(context0->mgpu()));
   }
 }
 


### PR DESCRIPTION
## Enhancements
- [x] `block_mapped`: Performance improvements.
- [x] Tested: Chesapeake, Hollywood, Road_USA, Delaunay.
- [x] SpMM kernel.
- [x] Block-mapped uses one exclusive scan instead of two.
- [x] (wip) merge_path_v2
- [x] Cooperative launch + other launch

## Known Issues
- Infinite loop on `bips`-like datasets using `block_mapped`, possibly due to negative weights?