### PR TITLE
Use `std::size_t` in graph loader 

### DIFF
--- a/include/gunrock/error.hxx
+++ b/include/gunrock/error.hxx
@@ -2,6 +2,7 @@
 
 #include <exception>
 #include <string>
+#include <cuda_runtime_api.h>
 
 namespace gunrock {
 
@@ -34,12 +35,12 @@ struct exception_t : std::exception {
  * @param status error_t error code (equivalent to cudaError_t).
  * @param message custom message to be appended to the error message.
  */
-void throw_if_exception(error_t status, std::string message = "") {
+inline void throw_if_exception(error_t status, std::string message = "") {
   if (status != cudaSuccess)
     throw exception_t(status, message);
 }
 
-void throw_if_exception(bool is_exception, std::string message = "") {
+inline void throw_if_exception(bool is_exception, std::string message = "") {
   if (is_exception)
     throw exception_t(message);
 }

--- a/include/gunrock/io/detail/mmio.cpp
+++ b/include/gunrock/io/detail/mmio.cpp
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <cstddef>
 
 #include <gunrock/io/detail/mmio.hxx>
 #include <gunrock/error.hxx>

--- a/include/gunrock/io/detail/mmio.cpp
+++ b/include/gunrock/io/detail/mmio.cpp
@@ -12,20 +12,21 @@
 #include <ctype.h>
 
 #include <gunrock/io/detail/mmio.hxx>
+#include <gunrock/error.hxx>
 
 int mm_read_unsymmetric_sparse(const char* fname,
-                               int* M_,
-                               int* N_,
-                               int* nz_,
+                               std::size_t* M_,
+                               std::size_t* N_,
+                               std::size_t* nz_,
                                double** val_,
-                               int** I_,
-                               int** J_) {
+                               std::size_t** I_,
+                               std::size_t** J_) {
   FILE* f;
   MM_typecode matcode;
-  int M, N, nz;
-  int i;
+  std::size_t M, N, nz;
+  std::size_t i;
   double* val;
-  int *I, *J;
+  std::size_t *I, *J;
 
   if ((f = fopen(fname, "r")) == NULL)
     return -1;
@@ -57,8 +58,8 @@ int mm_read_unsymmetric_sparse(const char* fname,
 
   /* reseve memory for matrices */
 
-  I = (int*)malloc(nz * sizeof(int));
-  J = (int*)malloc(nz * sizeof(int));
+  I = (std::size_t*)malloc(nz * sizeof(std::size_t));
+  J = (std::size_t*)malloc(nz * sizeof(std::size_t));
   val = (double*)malloc(nz * sizeof(double));
 
   *val_ = val;
@@ -70,8 +71,13 @@ int mm_read_unsymmetric_sparse(const char* fname,
   /*  (ANSI C X3.159-1989, Sec. 4.9.6.2, p. 136 lines 13-15)            */
 
   for (i = 0; i < nz; ++i) {
-    if (fscanf(f, "%d %d %lg\n", &I[i], &J[i], &val[i]))
+    if (fscanf(f, "%zu %zu %lg\n", &I[i], &J[i], &val[i]))
       ;
+
+    gunrock::error::throw_if_exception(I[i] == 0,
+                                       "Market file is zero-indexed");
+    gunrock::error::throw_if_exception(J[i] == 0,
+                                       "Market file is zero-indexed");
     I[i]--; /* adjust from 1-based to 0-based */
     J[i]--;
   }
@@ -175,7 +181,10 @@ int mm_write_mtx_crd_size(FILE* f, int M, int N, int nz) {
     return 0;
 }
 
-int mm_read_mtx_crd_size(FILE* f, int* M, int* N, int* nz) {
+int mm_read_mtx_crd_size(FILE* f,
+                         std::size_t* M,
+                         std::size_t* N,
+                         std::size_t* nz) {
   char line[MM_MAX_LINE_LENGTH];
   int num_items_read;
 
@@ -189,12 +198,12 @@ int mm_read_mtx_crd_size(FILE* f, int* M, int* N, int* nz) {
   } while (line[0] == '%');
 
   /* line[] is either blank or has M,N, nz */
-  if (sscanf(line, "%d %d %d", M, N, nz) == 3)
+  if (sscanf(line, "%zu %zu %zu", M, N, nz) == 3)
     return 0;
 
   else
     do {
-      num_items_read = fscanf(f, "%d %d %d", M, N, nz);
+      num_items_read = fscanf(f, "%zu %zu %zu", M, N, nz);
       if (num_items_read == EOF)
         return MM_PREMATURE_EOF;
     } while (num_items_read != 3);
@@ -242,29 +251,29 @@ int mm_write_mtx_array_size(FILE* f, int M, int N) {
 /******************************************************************/
 
 int mm_read_mtx_crd_data(FILE* f,
-                         int M,
-                         int N,
-                         int nz,
-                         int I[],
-                         int J[],
+                         std::size_t M,
+                         std::size_t N,
+                         std::size_t nz,
+                         std::size_t I[],
+                         std::size_t J[],
                          double val[],
                          MM_typecode matcode) {
-  int i;
+  std::size_t i;
   if (mm_is_complex(matcode)) {
     for (i = 0; i < nz; i++)
-      if (fscanf(f, "%d %d %lg %lg", &I[i], &J[i], &val[2 * i],
+      if (fscanf(f, "%zu %zu %lg %lg", &I[i], &J[i], &val[2 * i],
                  &val[2 * i + 1]) != 4)
         return MM_PREMATURE_EOF;
   } else if (mm_is_real(matcode)) {
     for (i = 0; i < nz; i++) {
-      if (fscanf(f, "%d %d %lg\n", &I[i], &J[i], &val[i]) != 3)
+      if (fscanf(f, "%zu %zu %lg\n", &I[i], &J[i], &val[i]) != 3)
         return MM_PREMATURE_EOF;
     }
   }
 
   else if (mm_is_pattern(matcode)) {
     for (i = 0; i < nz; i++)
-      if (fscanf(f, "%d %d", &I[i], &J[i]) != 2)
+      if (fscanf(f, "%zu %zu", &I[i], &J[i]) != 2)
         return MM_PREMATURE_EOF;
   } else
     return MM_UNSUPPORTED_TYPE;
@@ -273,22 +282,22 @@ int mm_read_mtx_crd_data(FILE* f,
 }
 
 int mm_read_mtx_crd_entry(FILE* f,
-                          int* I,
-                          int* J,
+                          std::size_t* I,
+                          std::size_t* J,
                           double* real,
                           double* imag,
                           MM_typecode matcode) {
   if (mm_is_complex(matcode)) {
-    if (fscanf(f, "%d %d %lg %lg", I, J, real, imag) != 4)
+    if (fscanf(f, "%zu %zu %lg %lg", I, J, real, imag) != 4)
       return MM_PREMATURE_EOF;
   } else if (mm_is_real(matcode)) {
-    if (fscanf(f, "%d %d %lg\n", I, J, real) != 3)
+    if (fscanf(f, "%zu %zu %lg\n", I, J, real) != 3)
       return MM_PREMATURE_EOF;
 
   }
 
   else if (mm_is_pattern(matcode)) {
-    if (fscanf(f, "%d %d", I, J) != 2)
+    if (fscanf(f, "%zu %zu", I, J) != 2)
       return MM_PREMATURE_EOF;
   } else
     return MM_UNSUPPORTED_TYPE;
@@ -305,11 +314,11 @@ int mm_read_mtx_crd_entry(FILE* f,
 ************************************************************************/
 
 int mm_read_mtx_crd(char* fname,
-                    int* M,
-                    int* N,
-                    int* nz,
-                    int** I,
-                    int** J,
+                    std::size_t* M,
+                    std::size_t* N,
+                    std::size_t* nz,
+                    std::size_t** I,
+                    std::size_t** J,
                     double** val,
                     MM_typecode* matcode) {
   int ret_code;
@@ -330,8 +339,8 @@ int mm_read_mtx_crd(char* fname,
   if ((ret_code = mm_read_mtx_crd_size(f, M, N, nz)) != 0)
     return ret_code;
 
-  *I = (int*)malloc(*nz * sizeof(int));
-  *J = (int*)malloc(*nz * sizeof(int));
+  *I = (std::size_t*)malloc(*nz * sizeof(std::size_t));
+  *J = (std::size_t*)malloc(*nz * sizeof(std::size_t));
   *val = NULL;
 
   if (mm_is_complex(*matcode)) {
@@ -370,15 +379,15 @@ int mm_write_banner(FILE* f, MM_typecode matcode) {
 }
 
 int mm_write_mtx_crd(char fname[],
-                     int M,
-                     int N,
-                     int nz,
-                     int I[],
-                     int J[],
+                     std::size_t M,
+                     std::size_t N,
+                     std::size_t nz,
+                     std::size_t I[],
+                     std::size_t J[],
                      double val[],
                      MM_typecode matcode) {
   FILE* f;
-  int i;
+  std::size_t i;
 
   if (strcmp(fname, "stdout") == 0)
     f = stdout;
@@ -390,18 +399,18 @@ int mm_write_mtx_crd(char fname[],
   fprintf(f, "%s\n", mm_typecode_to_str(matcode));
 
   /* print matrix sizes and nonzeros */
-  fprintf(f, "%d %d %d\n", M, N, nz);
+  fprintf(f, "%zu %zu %zu\n", M, N, nz);
 
   /* print values */
   if (mm_is_pattern(matcode))
     for (i = 0; i < nz; i++)
-      fprintf(f, "%d %d\n", I[i], J[i]);
+      fprintf(f, "%zu %zu\n", I[i], J[i]);
   else if (mm_is_real(matcode))
     for (i = 0; i < nz; i++)
-      fprintf(f, "%d %d %20.16g\n", I[i], J[i], val[i]);
+      fprintf(f, "%zu %zu %20.16g\n", I[i], J[i], val[i]);
   else if (mm_is_complex(matcode))
     for (i = 0; i < nz; i++)
-      fprintf(f, "%d %d %20.16g %20.16g\n", I[i], J[i], val[2 * i],
+      fprintf(f, "%zu %zu %20.16g %20.16g\n", I[i], J[i], val[2 * i],
               val[2 * i + 1]);
   else {
     if (f != stdout)

--- a/include/gunrock/io/detail/mmio.hxx
+++ b/include/gunrock/io/detail/mmio.hxx
@@ -34,12 +34,19 @@ typedef char MM_typecode[4];
 char* mm_typecode_to_str(MM_typecode matcode);
 
 int mm_read_banner(FILE* f, MM_typecode* matcode);
-int mm_read_mtx_crd_size(FILE* f, int* M, int* N, int* nz);
-int mm_read_mtx_array_size(FILE* f, int* M, int* N);
+int mm_read_mtx_crd_size(FILE* f,
+                         std::size_t* M,
+                         std::size_t* N,
+                         std::size_t* nz);
+
+int mm_read_mtx_array_size(FILE* f, std::size_t* M, std::size_t* N);
 
 int mm_write_banner(FILE* f, MM_typecode matcode);
-int mm_write_mtx_crd_size(FILE* f, int M, int N, int nz);
-int mm_write_mtx_array_size(FILE* f, int M, int N);
+int mm_write_mtx_crd_size(FILE* f,
+                          std::size_t M,
+                          std::size_t N,
+                          std::size_t nz);
+int mm_write_mtx_array_size(FILE* f, std::size_t M, std::size_t N);
 
 /********************* MM_typecode query fucntions ***************************/
 
@@ -126,37 +133,37 @@ int mm_is_valid(MM_typecode matcode); /* too complex for a macro */
 /*  high level routines */
 
 int mm_write_mtx_crd(char fname[],
-                     int M,
-                     int N,
-                     int nz,
-                     int I[],
-                     int J[],
+                     std::size_t M,
+                     std::size_t N,
+                     std::size_t nz,
+                     std::size_t I[],
+                     std::size_t J[],
                      double val[],
                      MM_typecode matcode);
 
 int mm_read_mtx_crd_data(FILE* f,
-                         int M,
-                         int N,
-                         int nz,
-                         int I[],
-                         int J[],
+                         std::size_t M,
+                         std::size_t N,
+                         std::size_t nz,
+                         std::size_t I[],
+                         std::size_t J[],
                          double val[],
                          MM_typecode matcode);
 
 int mm_read_mtx_crd_entry(FILE* f,
-                          int* I,
-                          int* J,
+                          std::size_t* I,
+                          std::size_t* J,
                           double* real,
                           double* img,
                           MM_typecode matcode);
 
 int mm_read_unsymmetric_sparse(const char* fname,
-                               int* M_,
-                               int* N_,
-                               int* nz_,
+                               std::size_t* M_,
+                               std::size_t* N_,
+                               std::size_t* nz_,
                                double** val_,
-                               int** I_,
-                               int** J_);
+                               std::size_t** I_,
+                               std::size_t** J_);
 
 #endif
 

--- a/include/gunrock/io/detail/mmio.hxx
+++ b/include/gunrock/io/detail/mmio.hxx
@@ -10,6 +10,8 @@
  *
  */
 
+#pragma once
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/include/gunrock/io/matrix_market.hxx
+++ b/include/gunrock/io/matrix_market.hxx
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <string>
+#include <limits>
 
 #include <gunrock/io/detail/mmio.hxx>
 
@@ -19,7 +20,6 @@
 #include <gunrock/formats/formats.hxx>
 #include <gunrock/memory.hxx>
 #include <gunrock/error.hxx>
-#include <limits>
 
 namespace gunrock {
 namespace io {

--- a/include/gunrock/io/matrix_market.hxx
+++ b/include/gunrock/io/matrix_market.hxx
@@ -18,6 +18,7 @@
 #include <gunrock/util/filepath.hxx>
 #include <gunrock/formats/formats.hxx>
 #include <gunrock/memory.hxx>
+#include <gunrock/error.hxx>
 
 namespace gunrock {
 namespace io {
@@ -132,8 +133,10 @@ struct matrix_market_t {
 
       // pattern matrix defines sparsity pattern, but not values
       for (vertex_t i = 0; i < num_nonzeros; ++i) {
-        assert(fscanf(file, " %d %d \n", &(coo.row_indices[i]),
-                      &(coo.column_indices[i])) == 2);
+        auto num_assigned = fscanf(file, " %d %d \n", &(coo.row_indices[i]),
+                                   &(coo.column_indices[i]));
+        error::throw_if_exception(num_assigned != 2,
+                                  "Could not read edge from market file");
         coo.row_indices[i]--;  // adjust from 1-based to 0-based indexing
         coo.column_indices[i]--;
         coo.nonzero_values[i] =
@@ -150,7 +153,9 @@ struct matrix_market_t {
         vertex_t J = 0;
         double V = 0.0f;
 
-        assert(fscanf(file, " %d %d %lf \n", &I, &J, &V) == 3);
+        auto num_assigned = fscanf(file, " %d %d %lf \n", &I, &J, &V);
+        error::throw_if_exception(
+            num_assigned != 3, "Could not read weighted edge from market file");
 
         coo.row_indices[i] = (vertex_t)I - 1;
         coo.column_indices[i] = (vertex_t)J - 1;

--- a/include/gunrock/io/matrix_market.hxx
+++ b/include/gunrock/io/matrix_market.hxx
@@ -19,6 +19,7 @@
 #include <gunrock/formats/formats.hxx>
 #include <gunrock/memory.hxx>
 #include <gunrock/error.hxx>
+#include <limits>
 
 namespace gunrock {
 namespace io {
@@ -112,14 +113,21 @@ struct matrix_market_t {
       exit(1);
     }
 
-    int num_rows, num_columns, num_nonzeros;  // XXX: requires all ints intially
+    std::size_t num_rows, num_columns, num_nonzeros;
     if ((mm_read_mtx_crd_size(file, &num_rows, &num_columns, &num_nonzeros)) !=
         0) {
       std::cerr << "Could not read file info (M, N, NNZ)" << std::endl;
       exit(1);
     }
 
-    // mtx are generally written as coordinate formaat
+    error::throw_if_exception(
+        num_rows >= std::numeric_limits<vertex_t>::max() ||
+            num_columns >= std::numeric_limits<vertex_t>::max(),
+        "vertex_t overflow");
+    error::throw_if_exception(
+        num_nonzeros >= std::numeric_limits<edge_t>::max(), "edge_t overflow");
+
+    // mtx are generally written as coordinate format
     format::coo_t<memory_space_t::host, vertex_t, edge_t, weight_t> coo(
         (vertex_t)num_rows, (vertex_t)num_columns, (edge_t)num_nonzeros);
 
@@ -133,12 +141,17 @@ struct matrix_market_t {
 
       // pattern matrix defines sparsity pattern, but not values
       for (vertex_t i = 0; i < num_nonzeros; ++i) {
-        auto num_assigned = fscanf(file, " %d %d \n", &(coo.row_indices[i]),
-                                   &(coo.column_indices[i]));
+        std::size_t row_index{0}, col_index{0};
+        auto num_assigned = fscanf(file, " %zu %zu \n", &row_index, &col_index);
         error::throw_if_exception(num_assigned != 2,
                                   "Could not read edge from market file");
-        coo.row_indices[i]--;  // adjust from 1-based to 0-based indexing
-        coo.column_indices[i]--;
+        error::throw_if_exception(row_index == 0,
+                                  "Market file is zero-indexed");
+        error::throw_if_exception(col_index == 0,
+                                  "Market file is zero-indexed");
+        // set and adjust from 1-based to 0-based indexing
+        coo.row_indices[i] = (vertex_t)row_index - 1;
+        coo.column_indices[i] = (vertex_t)col_index - 1;
         coo.nonzero_values[i] =
             (weight_t)1.0;  // use value 1.0 for all nonzero entries
       }
@@ -149,17 +162,22 @@ struct matrix_market_t {
         data = matrix_market_data_t::integer;
 
       for (vertex_t i = 0; i < coo.number_of_nonzeros; ++i) {
-        vertex_t I = 0;
-        vertex_t J = 0;
-        double V = 0.0f;
+        std::size_t row_index{0}, col_index{0};
+        double weight{0.0};
 
-        auto num_assigned = fscanf(file, " %d %d %lf \n", &I, &J, &V);
+        auto num_assigned =
+            fscanf(file, " %zu %zu %lf \n", &row_index, &col_index, &weight);
+
         error::throw_if_exception(
             num_assigned != 3, "Could not read weighted edge from market file");
+        error::throw_if_exception(row_index == 0,
+                                  "Market file is zero-indexed");
+        error::throw_if_exception(col_index == 0,
+                                  "Market file is zero-indexed");
 
-        coo.row_indices[i] = (vertex_t)I - 1;
-        coo.column_indices[i] = (vertex_t)J - 1;
-        coo.nonzero_values[i] = (weight_t)V;
+        coo.row_indices[i] = (vertex_t)row_index - 1;
+        coo.column_indices[i] = (vertex_t)col_index - 1;
+        coo.nonzero_values[i] = (weight_t)weight;
       }
     } else {
       std::cerr << "Unrecognized matrix market format type" << std::endl;


### PR DESCRIPTION
- Fix a bug when `NDEBUG` is defined, causing calls inside asserts to get discarded
- Assume `std::size_t` when loading market file
- Throw exceptions for overflow/underflow cases