### PR TITLE
Add my changes from SPMV experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,11 @@ eval/
 
 # Ignore build directory
 build
+build_release
+build_debug
 
 # Ignore external fetched content
 externals/*
+
+# Ignore slurm files
+slurm-*.out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ set(PROJECT_DEPS_DIR externals)
 include(${PROJECT_SOURCE_DIR}/cmake/FetchThrustCUB.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/FetchModernGPU.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/FetchCXXOpts.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/FetchRapidJSON.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/FetchNlohmannJson.cmake)
 # end /* Include cmake modules */
 
 ## Set the directory where the binaries will be stored
@@ -71,7 +73,7 @@ set_target_properties(essentials
     CUDA_EXTENSIONS OFF
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
     CUDA_SEPARABLE_COMPILATION ON
-    CUDA_ARCHITECTURES 61 # Set required architecture.
+    CUDA_ARCHITECTURES 86 # Set required architecture.
     # CUDA_PTX_COMPILATION ON # Can only be applied to OBJ.
 )
 
@@ -111,6 +113,7 @@ target_include_directories(essentials
   INTERFACE ${CUB_INCLUDE_DIR}
   INTERFACE ${MODERNGPU_INCLUDE_DIR}
   INTERFACE ${RAPIDJSON_INCLUDE_DIR}
+  INTERFACE ${NHLOMANN_JSON_INCLUDE_DIR}
   INTERFACE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
 )
 
@@ -120,6 +123,7 @@ target_include_directories(essentials
 target_link_libraries(essentials
   INTERFACE curand
   INTERFACE cuda
+  INTERFACE cusparse
 )
 
 ####################################################
@@ -162,6 +166,9 @@ set(CUDA_FLAGS
   # --device-debug # Device debug
 )
 
+set(CMAKE_CUDA_FLAGS_DEBUG "--optimize 0 --debug --device-debug -g -G")
+set(CMAKE_CUDA_FLAGS_RELEASE "--optimize 3")
+
 ####################################################
 ############ TARGET COMPILE OPTIONS ################
 ####################################################
@@ -187,11 +194,12 @@ endif(ESSENTIALS_BUILD_EXAMPLES)
 ####################################################
 option(ESSENTIALS_BUILD_TESTS
   "If on, builds the unit tests."
-  OFF)
+  ON)
 
 # Subdirectories for examples, testing and documentation
 if(ESSENTIALS_BUILD_TESTS)
   include(${PROJECT_SOURCE_DIR}/cmake/FetchGoogleTest.cmake)
+  enable_testing()
   add_subdirectory(unittests)
 endif(ESSENTIALS_BUILD_TESTS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ set_target_properties(essentials
     CUDA_EXTENSIONS OFF
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
     CUDA_SEPARABLE_COMPILATION ON
-    CUDA_ARCHITECTURES 86 # Set required architecture.
+    CUDA_ARCHITECTURES 61 # Set required architecture.
     # CUDA_PTX_COMPILATION ON # Can only be applied to OBJ.
 )
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Simple Makefile to handle release/debug modes
+# As well as other CMake command line args
+# (which are hard to type and remember)
+
+all: release
+
+release:
+	mkdir -p build_release
+	cd build_release && cmake -DCMAKE_BUILD_TYPE=RELEASE ..
+	$(MAKE) -C ./build_release
+
+debug:
+	mkdir -p build_debug
+	cd build_debug && cmake -DCMAKE_BUILD_TYPE=DEBUG ..
+	$(MAKE) -C ./build_debug
+
+test: release
+	./build_release/bin/unittests
+
+test_release: test
+
+test_debug: debug
+	./build_debug/bin/unittests
+
+clean:
+	rm -rf build_debug
+	rm -rf build_release
+	rm -rf externals

--- a/cmake/FetchNlohmannJson.cmake
+++ b/cmake/FetchNlohmannJson.cmake
@@ -1,0 +1,21 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET ON)
+
+message(STATUS "Cloning External Project: NLohmannJson")
+get_filename_component(FC_BASE "../externals"
+                REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+set(FETCHCONTENT_BASE_DIR ${FC_BASE})
+
+FetchContent_Declare(
+  json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG        v3.10.5
+)
+
+FetchContent_GetProperties(json)
+if(NOT json_POPULATED)
+  FetchContent_Populate(
+    json
+  )
+endif()
+set(NHLOMANN_JSON_INCLUDE_DIR "${json_SOURCE_DIR}/include")

--- a/cmake/FetchRapidJSON.cmake
+++ b/cmake/FetchRapidJSON.cmake
@@ -1,0 +1,21 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET ON)
+
+message(STATUS "Cloning External Project: RapidJSON")
+get_filename_component(FC_BASE "../externals"
+                REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+set(FETCHCONTENT_BASE_DIR ${FC_BASE})
+
+FetchContent_Declare(
+  rapidjson
+    GIT_REPOSITORY https://github.com/Tencent/rapidjson
+    GIT_TAG        master
+)
+
+FetchContent_GetProperties(rapidjson)
+if(NOT rapidjson_POPULATED)
+  FetchContent_Populate(
+    rapidjson
+  )
+endif()
+set(RAPIDJSON_INCLUDE_DIR "${rapidjson_SOURCE_DIR}/include")

--- a/include/gunrock/graph/csr.hxx
+++ b/include/gunrock/graph/csr.hxx
@@ -113,6 +113,21 @@ class graph_csr_t {
     return values;
   }
 
+  // Graph type (inherited from this class) has equivalents of this in graph 
+  // terminology (vertices and edges). Also include these for linear algebra
+  // terminology
+  __host__ __device__ __forceinline__ auto get_number_of_rows() const {
+    return number_of_vertices;
+  }
+
+  __host__ __device__ __forceinline__ auto get_number_of_columns() const {
+    return number_of_vertices;
+  }
+
+  __host__ __device__ __forceinline__ auto get_number_of_nonzeros() const {
+    return number_of_edges;
+  }
+
  protected:
   __host__ __device__ void set(vertex_type const& _number_of_vertices,
                                edge_type const& _number_of_edges,

--- a/include/gunrock/io/matrix_market.hxx
+++ b/include/gunrock/io/matrix_market.hxx
@@ -113,7 +113,14 @@ struct matrix_market_t {
       exit(1);
     }
 
+    // Make sure we're actually reading a matrix, and not an array
+    if (mm_is_array(code)) {
+      std::cerr << "File is not a sparse matrix" << std::endl;
+      exit(1);
+    }
+
     std::size_t num_rows, num_columns, num_nonzeros;
+
     if ((mm_read_mtx_crd_size(file, &num_rows, &num_columns, &num_nonzeros)) !=
         0) {
       std::cerr << "Could not read file info (M, N, NNZ)" << std::endl;

--- a/include/gunrock/util/timer.hxx
+++ b/include/gunrock/util/timer.hxx
@@ -32,6 +32,7 @@ struct timer_t {
   void begin() { cudaEventRecord(start_); }
   void start() { this->begin(); }
 
+  // Alias of each other, stop the timer.
   float end() {
     cudaEventRecord(stop_);
     cudaEventSynchronize(stop_);
@@ -39,6 +40,7 @@ struct timer_t {
 
     return milliseconds();
   }
+  float stop() { return this->end(); }
 
   float seconds() { return time * 1e-3; }
   float milliseconds() { return time; }

--- a/unittests/framework/operators/for.cuh
+++ b/unittests/framework/operators/for.cuh
@@ -15,8 +15,6 @@
 
 #include <gtest/gtest.h>
 
-using namespace gunrock;
-
 /// It is not valid in CUDA/NVCC to use a lambda within TEST().
 /// error: The enclosing parent function ("TestBody") for an extended
 /// __device__ lambda cannot have private or protected access within its class
@@ -26,23 +24,23 @@ struct f {
 
 TEST(operators, prallel_for) {
   // Build a sample graph using the sample csr.
-  auto csr = io::sample::csr();
-  auto G =
-      graph::build::from_csr<memory_space_t::device, graph::view_t::csr>(csr);
+  auto csr = gunrock::io::sample::csr();
+  auto G = gunrock::graph::build::from_csr<gunrock::memory_space_t::device,
+                                           gunrock::graph::view_t::csr>(csr);
 
   // Initialize the devicecontext.
-  cuda::device_id_t device = 0;
-  cuda::multi_context_t context(device);
+  gunrock::cuda::device_id_t device = 0;
+  gunrock::cuda::multi_context_t context(device);
 
   // Launch for using a separate function.
-  operators::parallel_for::execute<operators::parallel_for_each_t::vertex>(
-      G, f(), context);
+  gunrock::operators::parallel_for::execute<
+      gunrock::operators::parallel_for_each_t::vertex>(G, f(), context);
 
   // Build a sample frontier.
-  frontier::frontier_t<int, int> X;
+  gunrock::frontier::frontier_t<int, int> X;
   X.push_back(1);
 
   // Launch for on a frontier.
-  operators::parallel_for::execute<operators::parallel_for_each_t::element>(
-      X, f(), context);
+  gunrock::operators::parallel_for::execute<
+      gunrock::operators::parallel_for_each_t::element>(X, f(), context);
 }


### PR DESCRIPTION
- Fix collusion with `cuda` namespace in libcu++
- Additional error handling for matrix market files
- JSON libraries
- Add a helpful makefile
- Add debug and release modes
- Support custom CUDA streams for contexts