### PR TITLE
Add Triangle Counting algorithm

### DIFF
--- a/examples/algorithms/CMakeLists.txt
+++ b/examples/algorithms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(kcore)
 add_subdirectory(spmv)
 add_subdirectory(spgemm)
 add_subdirectory(mst)
+add_subdirectory(tc)
 # end /* Add algorithms' subdirectories */
 
 # begin /* Add experimental algorithms' subdirectories */

--- a/examples/algorithms/tc/CMakeLists.txt
+++ b/examples/algorithms/tc/CMakeLists.txt
@@ -1,0 +1,21 @@
+# begin /* Set the application name. */
+set(APPLICATION_NAME tc)
+# end /* Set the application name. */
+
+# begin /* Add CUDA executables */
+add_executable(${APPLICATION_NAME})
+
+set(SOURCE_LIST
+    ${APPLICATION_NAME}.cu
+)
+
+target_sources(${APPLICATION_NAME} PRIVATE ${SOURCE_LIST})
+target_link_libraries(${APPLICATION_NAME} PRIVATE essentials)
+get_target_property(ESSENTIALS_ARCHITECTURES essentials CUDA_ARCHITECTURES)
+set_target_properties(${APPLICATION_NAME}
+    PROPERTIES
+        CUDA_ARCHITECTURES ${ESSENTIALS_ARCHITECTURES}
+) # XXX: Find a better way to inherit essentials properties.
+
+message(STATUS "Example Added: ${APPLICATION_NAME}")
+# end /* Add CUDA executables */

--- a/examples/algorithms/tc/tc.cu
+++ b/examples/algorithms/tc/tc.cu
@@ -1,0 +1,74 @@
+#include <gunrock/algorithms/tc.hxx>
+
+using namespace gunrock;
+using namespace memory;
+
+void test_tc(int num_arguments, char** argument_array) {
+  if (num_arguments != 2) {
+    std::cerr << "usage: ./bin/tc filename.mtx" << std::endl;
+    exit(1);
+  }
+
+  // --
+  // Define types
+
+  using vertex_t = int;
+  using edge_t = int;
+  using weight_t = float;
+  using count_t = int;
+
+  using csr_t =
+      format::csr_t<memory_space_t::device, vertex_t, edge_t, weight_t>;
+  csr_t csr;
+
+  // --
+  // IO
+
+  std::string filename = argument_array[1];
+
+  if (util::is_market(filename)) {
+    io::matrix_market_t<vertex_t, edge_t, weight_t> mm;
+    csr.from_coo(mm.load(filename));
+  } else if (util::is_binary_csr(filename)) {
+    csr.read_binary(filename);
+  } else {
+    std::cerr << "Unknown file format: " << filename << std::endl;
+    exit(1);
+  }
+
+  // --
+  // Build graph
+
+  auto G = graph::build::from_csr<memory_space_t::device,
+                                  graph::view_t::csr>(
+      csr.number_of_rows,               // rows
+      csr.number_of_columns,            // columns
+      csr.number_of_nonzeros,           // nonzeros
+      csr.row_offsets.data().get(),     // row_offsets
+      csr.column_indices.data().get(),  // column_indices
+      csr.nonzero_values.data().get()   // values
+  );  // supports row_indices and column_offsets (default = nullptr)
+
+  // --
+  // Params and memory allocation
+  srand(time(NULL));
+
+  vertex_t n_vertices = G.get_number_of_vertices();
+  thrust::device_vector<count_t> triangles_count(n_vertices, 0);
+  std::cout << "TC for graph with n_vertices = " << n_vertices << std::endl;
+
+  // --
+  // GPU Run
+
+  float gpu_elapsed = tc::run(G, triangles_count.data().get());
+
+  // --
+  // Log + Validate
+  print::head(triangles_count, 40, "Per-vertex triangle count");
+
+  std::cout << "GPU Elapsed Time : " << gpu_elapsed << " (ms)" << std::endl;
+}
+
+int main(int argc, char** argv) {
+  test_tc(argc, argv);
+}

--- a/examples/algorithms/tc/tc.cu
+++ b/examples/algorithms/tc/tc.cu
@@ -4,18 +4,18 @@ using namespace gunrock;
 using namespace memory;
 
 void test_tc(int num_arguments, char** argument_array) {
-  if (num_arguments != 2) {
-    std::cerr << "usage: ./bin/tc filename.mtx" << std::endl;
+  if (num_arguments != 3) {
+    std::cerr << "usage: ./bin/tc filename.mtx reduce" << std::endl;
     exit(1);
   }
 
   // --
   // Define types
 
-  using vertex_t = int;
-  using edge_t = int;
+  using vertex_t = uint32_t;
+  using edge_t = uint32_t;
   using weight_t = float;
-  using count_t = int;
+  using count_t = vertex_t;
 
   using csr_t =
       format::csr_t<memory_space_t::device, vertex_t, edge_t, weight_t>;
@@ -24,11 +24,18 @@ void test_tc(int num_arguments, char** argument_array) {
   // --
   // IO
 
-  std::string filename = argument_array[1];
+  const std::string filename = argument_array[1];
+  const std::string reduce = argument_array[2];
+  const bool reduce_all_triangles = reduce.find("true") != std::string::npos;
 
   if (util::is_market(filename)) {
     io::matrix_market_t<vertex_t, edge_t, weight_t> mm;
-    csr.from_coo(mm.load(filename));
+    auto mmatrix = mm.load(filename);
+    if (!mm_is_symmetric(mm.code)) {
+      std::cerr << "Error: input matrix must be symmetric" << std::endl;
+      exit(1);
+    }
+    csr.from_coo(mmatrix);
   } else if (util::is_binary_csr(filename)) {
     csr.read_binary(filename);
   } else {
@@ -47,25 +54,28 @@ void test_tc(int num_arguments, char** argument_array) {
       csr.row_offsets.data().get(),     // row_offsets
       csr.column_indices.data().get(),  // column_indices
       csr.nonzero_values.data().get()   // values
-  );  // supports row_indices and column_offsets (default = nullptr)
+  );
 
   // --
   // Params and memory allocation
-  srand(time(NULL));
 
   vertex_t n_vertices = G.get_number_of_vertices();
   thrust::device_vector<count_t> triangles_count(n_vertices, 0);
-  std::cout << "TC for graph with n_vertices = " << n_vertices << std::endl;
 
   // --
   // GPU Run
 
-  float gpu_elapsed = tc::run(G, triangles_count.data().get());
+  std::size_t total_triangles = 0;
+  float gpu_elapsed = tc::run(G, reduce_all_triangles,
+                              triangles_count.data().get(), &total_triangles);
 
   // --
-  // Log + Validate
-  print::head(triangles_count, 40, "Per-vertex triangle count");
+  // Log
 
+  print::head(triangles_count, 40, "Per-vertex triangle count");
+  if (reduce_all_triangles) {
+    std::cout << "Total Graph Traingles : " << total_triangles << std::endl;
+  }
   std::cout << "GPU Elapsed Time : " << gpu_elapsed << " (ms)" << std::endl;
 }
 

--- a/include/gunrock/algorithms/search/binary_search.hxx
+++ b/include/gunrock/algorithms/search/binary_search.hxx
@@ -41,9 +41,11 @@ namespace binary {
 // that the element found will be leftmost or rightmost element.
 // XXX: Implement Search
 template <typename key_pointer_t, typename key_t, typename int_t>
-__host__ __device__ int_t
-execute(const key_pointer_t& keys, const key_t& key, int_t begin, int_t end) {
-  bound_t bounds = bound_t::upper;
+__host__ __device__ int_t execute(const key_pointer_t& keys,
+                                  const key_t& key,
+                                  int_t begin,
+                                  int_t end,
+                                  const bound_t bounds = bound_t::upper) {
   auto comp = [](const key_t& a, const key_t& b) { return a < b; };
   while (begin < end) {
     int_t mid = (begin + end) / 2;

--- a/include/gunrock/algorithms/tc.hxx
+++ b/include/gunrock/algorithms/tc.hxx
@@ -65,14 +65,6 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
   using weight_t = typename problem_t::weight_t;
   using frontier_t = typename enactor_t<problem_t>::frontier_t;
 
-  void prepare_frontier(frontier_t* f,
-                        gcuda::multi_context_t& context) override {
-    auto P = this->get_problem();
-    auto n_vertices = P->get_graph().get_number_of_vertices();
-
-    f->sequence((vertex_t)0, n_vertices, context.get_context(0)->stream());
-  }
-
   void loop(gcuda::multi_context_t& context) override {
     // Data slice
     auto E = this->get_enactor();

--- a/include/gunrock/algorithms/tc.hxx
+++ b/include/gunrock/algorithms/tc.hxx
@@ -1,0 +1,130 @@
+/**
+ * @file sssp.hxx
+ * @author Muhammad A. Awad (mawad@ucdavis.edu)
+ * @brief Triangle Counting algorithm.
+ * @version 0.1
+ * @date 2022-08-06
+ *
+ * @copyright Copyright (c) 2022
+ *
+ */
+#pragma once
+
+#include <gunrock/algorithms/algorithms.hxx>
+
+namespace gunrock {
+namespace tc {
+
+template <typename vertex_t>
+struct param_t {
+  // No parameters for this algorithm
+};
+
+template <typename vertex_t>
+struct result_t {
+  vertex_t* triangles_count;
+  result_t(vertex_t* _triangles_count) : triangles_count(_triangles_count) {}
+};
+
+template <typename graph_t, typename param_type, typename result_type>
+struct problem_t : gunrock::problem_t<graph_t> {
+  param_type param;
+  result_type result;
+
+  problem_t(graph_t& G,
+            param_type& _param,
+            result_type& _result,
+            std::shared_ptr<gcuda::multi_context_t> _context)
+      : gunrock::problem_t<graph_t>(G, _context),
+        param(_param),
+        result(_result) {}
+
+  using vertex_t = typename graph_t::vertex_type;
+  using edge_t = typename graph_t::edge_type;
+
+  void init() override {}
+
+  void reset() override {}
+};
+
+template <typename problem_t>
+struct enactor_t : gunrock::enactor_t<problem_t> {
+  enactor_t(problem_t* _problem,
+            std::shared_ptr<gcuda::multi_context_t> _context)
+      : gunrock::enactor_t<problem_t>(_problem, _context) {}
+
+  using vertex_t = typename problem_t::vertex_t;
+  using edge_t = typename problem_t::edge_t;
+  using weight_t = typename problem_t::weight_t;
+  using frontier_t = typename enactor_t<problem_t>::frontier_t;
+
+  void prepare_frontier(frontier_t* f,
+                        gcuda::multi_context_t& context) override {
+    auto P = this->get_problem();
+    auto n_vertices = P->get_graph().get_number_of_vertices();
+
+    f->sequence((vertex_t)0, n_vertices, context.get_context(0)->stream());
+  }
+
+  void loop(gcuda::multi_context_t& context) override {
+    // Data slice
+    auto E = this->get_enactor();
+    auto P = this->get_problem();
+    auto G = P->get_graph();
+
+    auto triangles_count = P->result.triangles_count;
+    auto iteration = this->iteration;
+
+    auto intersect = [G, triangles_count] __host__ __device__(
+                         vertex_t const& source,    // ... source
+                         vertex_t const& neighbor,  // neighbor
+                         edge_t const& edge,        // edge
+                         weight_t const& weight     // weight (tuple).
+                         ) -> bool {
+      if (source < neighbor) {
+        auto src_triangles_count = G.get_intersection_count(source, neighbor);
+        math::atomic::add(&(triangles_count[source]), src_triangles_count);
+      }
+      return false;
+    };
+
+    // Execute advance operator on the provided lambda
+    operators::advance::execute<operators::load_balance_t::block_mapped>(
+        G, E, intersect, context);
+    std::cout << "iteration: " << iteration << std::endl;
+  }
+
+};  // struct enactor_t
+
+template <typename graph_t>
+float run(graph_t& G,
+          typename graph_t::vertex_type* triangles_count,  // Output
+          std::shared_ptr<gcuda::multi_context_t> context =
+              std::shared_ptr<gcuda::multi_context_t>(
+                  new gcuda::multi_context_t(0))  // Context
+) {
+  // <user-defined>
+  using vertex_t = typename graph_t::vertex_type;
+  using weight_t = typename graph_t::weight_type;
+
+  using param_type = param_t<vertex_t>;
+  using result_type = result_t<vertex_t>;
+
+  param_type param;
+  result_type result(triangles_count);
+  // </user-defined>
+
+  using problem_type = problem_t<graph_t, param_type, result_type>;
+  using enactor_type = enactor_t<problem_type>;
+
+  problem_type problem(G, param, result, context);
+  problem.init();
+  problem.reset();
+
+  enactor_type enactor(&problem, context);
+  return enactor.enact();
+  // </boiler-plate>
+}
+
+}  // namespace tc
+}  // namespace gunrock

--- a/include/gunrock/algorithms/tc.hxx
+++ b/include/gunrock/algorithms/tc.hxx
@@ -1,5 +1,5 @@
 /**
- * @file sssp.hxx
+ * @file tc.hxx
  * @author Muhammad A. Awad (mawad@ucdavis.edu)
  * @brief Triangle Counting algorithm.
  * @version 0.1
@@ -100,9 +100,7 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
     // Execute advance operator on the provided lambda
     operators::advance::execute<operators::load_balance_t::block_mapped>(
         G, E, intersect, context);
-    std::cout << "iteration: " << iteration << std::endl;
   }
-
 };  // struct enactor_t
 
 template <typename graph_t>

--- a/include/gunrock/algorithms/tc.hxx
+++ b/include/gunrock/algorithms/tc.hxx
@@ -17,13 +17,18 @@ namespace tc {
 
 template <typename vertex_t>
 struct param_t {
-  // No parameters for this algorithm
+  bool reduce_all_triangles;
+  param_t(bool _reduce_all_triangles)
+      : reduce_all_triangles(_reduce_all_triangles) {}
 };
 
 template <typename vertex_t>
 struct result_t {
-  vertex_t* triangles_count;
-  result_t(vertex_t* _triangles_count) : triangles_count(_triangles_count) {}
+  vertex_t* vertex_triangles_count;
+  std::size_t* total_triangles_count;
+  result_t(vertex_t* _vertex_triangles_count, uint64_t* _total_triangles_count)
+      : vertex_triangles_count(_vertex_triangles_count),
+        total_triangles_count(_total_triangles_count) {}
 };
 
 template <typename graph_t, typename param_type, typename result_type>
@@ -72,18 +77,22 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
     auto P = this->get_problem();
     auto G = P->get_graph();
 
-    auto triangles_count = P->result.triangles_count;
+    auto vertex_triangles_count = P->result.vertex_triangles_count;
     auto iteration = this->iteration;
 
-    auto intersect = [G, triangles_count] __host__ __device__(
+    auto intersect = [G, vertex_triangles_count] __host__ __device__(
                          vertex_t const& source,    // ... source
                          vertex_t const& neighbor,  // neighbor
                          edge_t const& edge,        // edge
                          weight_t const& weight     // weight (tuple).
                          ) -> bool {
-      if (source < neighbor) {
-        auto src_triangles_count = G.get_intersection_count(source, neighbor);
-        math::atomic::add(&(triangles_count[source]), src_triangles_count);
+      if (neighbor > source) {
+        auto src_vertex_triangles_count = G.get_intersection_count(
+            source, neighbor,
+            [vertex_triangles_count](auto intersection_vertex) {
+              math::atomic::add(&(vertex_triangles_count[intersection_vertex]),
+                                vertex_t{1});
+            });
       }
       return false;
     };
@@ -98,7 +107,9 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
 
 template <typename graph_t>
 float run(graph_t& G,
-          typename graph_t::vertex_type* triangles_count,  // Output
+          bool reduce_all_triangles,
+          typename graph_t::vertex_type* vertex_triangles_count,  // Output
+          std::size_t* total_triangles_count,                     // Output
           std::shared_ptr<gcuda::multi_context_t> context =
               std::shared_ptr<gcuda::multi_context_t>(
                   new gcuda::multi_context_t(0))  // Context
@@ -110,8 +121,8 @@ float run(graph_t& G,
   using param_type = param_t<vertex_t>;
   using result_type = result_t<vertex_t>;
 
-  param_type param;
-  result_type result(triangles_count);
+  param_type param(reduce_all_triangles);
+  result_type result(vertex_triangles_count, total_triangles_count);
   // </user-defined>
 
   using problem_type = problem_t<graph_t, param_type, result_type>;
@@ -122,8 +133,21 @@ float run(graph_t& G,
   problem.reset();
 
   enactor_type enactor(&problem, context);
-  return enactor.enact();
+  auto time = enactor.enact();
+
+  if (param.reduce_all_triangles) {
+    auto policy = context->get_context(0)->execution_policy();
+    *result.total_triangles_count = thrust::transform_reduce(
+        policy, result.vertex_triangles_count,
+        result.vertex_triangles_count + G.get_number_of_vertices(),
+        [] __device__(const vertex_t& vertex_triangles) {
+          return static_cast<std::size_t>(vertex_triangles);
+        },
+        std::size_t{0}, thrust::plus<std::size_t>());
+  }
+
   // </boiler-plate>
+  return time;
 }
 
 }  // namespace tc

--- a/include/gunrock/framework/enactor.hxx
+++ b/include/gunrock/framework/enactor.hxx
@@ -161,15 +161,15 @@ struct enactor_t {
   enactor_t(algorithm_problem_t* _problem,
             std::shared_ptr<gcuda::multi_context_t> _context,
             enactor_properties_t _properties = enactor_properties_t())
-      : problem(_problem),
-        properties(_properties),
+      : properties(_properties),
         context(_context),
+        problem(_problem),
         frontiers(properties.number_of_frontier_buffers),
+        scanned_work_domain(problem->get_graph().get_number_of_vertices() + 1),
         active_frontier(reinterpret_cast<frontier_t*>(&frontiers[0])),
         inactive_frontier(reinterpret_cast<frontier_t*>(&frontiers[1])),
         buffer_selector(0),
-        iteration(0),
-        scanned_work_domain(problem->get_graph().get_number_of_vertices() + 1) {
+        iteration(0) {
     /*!
      * If the self manage frontiers property is false, the enactor interface
      * will resize the frontier buffers ahead of time to avoid the first

--- a/include/gunrock/framework/operators/advance/block_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/block_mapped.hxx
@@ -99,8 +99,8 @@ __global__ void __launch_bounds__(THREADS_PER_BLOCK, 2)
     if (local_idx == 0)
       offset[0] = math::atomic::add(
           &block_offsets[0], (offset_counter_t)aggregate_degree_per_block);
-    __syncthreads();
   }
+  __syncthreads();
 
   auto length = global_idx - local_idx + gcuda::block::size::x();
 

--- a/include/gunrock/graph/coo.hxx
+++ b/include/gunrock/graph/coo.hxx
@@ -105,6 +105,14 @@ class graph_coo_t {
     return values;
   }
 
+  __host__ __device__ __forceinline__ auto get_number_of_vertices() const {
+    return number_of_vertices;
+  }
+
+  __host__ __device__ __forceinline__ auto get_number_of_edges() const {
+    return number_of_edges;
+  }
+
  protected:
   __host__ __device__ void set(vertex_type const& _number_of_vertices,
                                edge_type const& _number_of_edges,
@@ -121,8 +129,8 @@ class graph_coo_t {
 
  private:
   // Underlying data storage
-  vertex_type number_of_vertices;  // XXX: redundant
-  edge_type number_of_edges;       // XXX: redundant
+  vertex_type number_of_vertices;
+  edge_type number_of_edges;
 
   vertex_type* row_indices;
   vertex_type* column_indices;

--- a/include/gunrock/graph/csc.hxx
+++ b/include/gunrock/graph/csc.hxx
@@ -108,6 +108,14 @@ class graph_csc_t {
     return values;
   }
 
+  __host__ __device__ __forceinline__ auto get_number_of_vertices() const {
+    return number_of_vertices;
+  }
+
+  __host__ __device__ __forceinline__ auto get_number_of_edges() const {
+    return number_of_edges;
+  }
+
  protected:
   __host__ __device__ void set(vertex_type const& _number_of_vertices,
                                edge_type const& _number_of_edges,
@@ -124,8 +132,8 @@ class graph_csc_t {
 
  private:
   // Underlying data storage
-  vertex_type number_of_vertices;  // XXX: redundant
-  edge_type number_of_edges;       // XXX: redundant
+  vertex_type number_of_vertices;
+  edge_type number_of_edges;
 
   edge_type* offsets;
   vertex_type* indices;

--- a/include/gunrock/graph/csr.hxx
+++ b/include/gunrock/graph/csr.hxx
@@ -121,13 +121,12 @@ class graph_csr_t {
     auto destination_neighbors_count = get_number_of_neighbors(destination);
 
     if (source_neighbors_count == 0 || destination_neighbors_count == 0) {
-      printf("Singleton node\n");
       return 0;
     }
-    // if (source_neighbors_count > destination_neighbors_count) {
-    //   std::swap(intersection_source, intersection_destination);
-    //   std::swap(source_neighbors_count, destination_neighbors_count);
-    // }
+    if (source_neighbors_count > destination_neighbors_count) {
+      std::swap(intersection_source, intersection_destination);
+      std::swap(source_neighbors_count, destination_neighbors_count);
+    }
 
     auto source_offset = offsets[intersection_source];
     auto destination_offset = offsets[intersection_destination];
@@ -229,8 +228,8 @@ class graph_csr_t {
 
  private:
   // Underlying data storage
-  vertex_type number_of_vertices;  
-  edge_type number_of_edges;       
+  vertex_type number_of_vertices;
+  edge_type number_of_edges;
 
   edge_type* offsets;
   vertex_type* indices;

--- a/include/gunrock/graph/csr.hxx
+++ b/include/gunrock/graph/csr.hxx
@@ -111,16 +111,19 @@ class graph_csr_t {
                          operator_type on_intersection) const {
     vertex_type intersection_count = 0;
 
+    auto intersection_source = source;
+    auto intersection_destination = destination;
+
     auto source_neighbors_count = get_number_of_neighbors(source);
     auto destination_neighbors_count = get_number_of_neighbors(destination);
 
-    auto source_offset = offsets[source];
-    auto destination_offset = offsets[destination];
+    if (source_neighbors_count > destination_neighbors_count) {
+      std::swap(intersection_source, intersection_destination);
+      std::swap(source_neighbors_count, destination_neighbors_count);
+    }
 
-    // if (source_neighbors_count > destination_neighbors_count) {
-    //   std::swap(source_offset, destination_offset);
-    //   std::swap(source_neighbors_count, destination_neighbors_count);
-    // }
+    auto source_offset = offsets[intersection_source];
+    auto destination_offset = offsets[intersection_destination];
 
     auto source_edges_iter = indices + source_offset;
     auto destination_edges_iter = indices + destination_offset;

--- a/include/gunrock/graph/csr.hxx
+++ b/include/gunrock/graph/csr.hxx
@@ -205,6 +205,14 @@ class graph_csr_t {
     return number_of_edges;
   }
 
+  __host__ __device__ __forceinline__ auto get_number_of_vertices() const {
+    return number_of_vertices;
+  }
+
+  __host__ __device__ __forceinline__ auto get_number_of_edges() const {
+    return number_of_edges;
+  }
+
  protected:
   __host__ __device__ void set(vertex_type const& _number_of_vertices,
                                edge_type const& _number_of_edges,
@@ -221,8 +229,8 @@ class graph_csr_t {
 
  private:
   // Underlying data storage
-  vertex_type number_of_vertices;  // XXX: redundant
-  edge_type number_of_edges;       // XXX: redundant
+  vertex_type number_of_vertices;  
+  edge_type number_of_edges;       
 
   edge_type* offsets;
   vertex_type* indices;

--- a/include/gunrock/graph/csr.hxx
+++ b/include/gunrock/graph/csr.hxx
@@ -135,10 +135,6 @@ class graph_csr_t {
     auto destination_edges_iter = indices + destination_offset;
 
     auto needle = *destination_edges_iter;
-    // auto source_search_start =
-    //     search::binary::execute(source_edges_iter, needle, vertex_t{0},
-    //                             source_neighbors_count,
-    //                             search::bound_t::lower);
 
     auto source_search_start = thrust::distance(
         source_edges_iter,

--- a/include/gunrock/graph/csr.hxx
+++ b/include/gunrock/graph/csr.hxx
@@ -133,26 +133,16 @@ class graph_csr_t {
         search::binary::execute(source_edges_iter, needle, vertex_t{0},
                                 source_neighbors_count, search::bound_t::lower);
     edge_type destination_search_start = 0;
-    // printf("[%i -> %i] %i, [%i, %i], [%i, %i]\n", source, destination,
-    // needle,
-    //        source_search_start, destination_search_start,
-    //        source_neighbors_count, destination_neighbors_count);
 
     while (source_search_start < source_neighbors_count &&
            destination_search_start < destination_neighbors_count) {
       auto cur_edge_src = source_edges_iter[source_search_start];
       auto cur_edge_dst = destination_edges_iter[destination_search_start];
-      // printf("%i, %i | %i, %i\n", cur_edge_src, cur_edge_dst,
-      //        source_search_start, destination_search_start);
-      // if (source == 1 and destination == 2) {
-      //   printf("%i, %i\n", cur_edge_src, cur_edge_dst);
-      // }
       if (cur_edge_src == cur_edge_dst) {
         intersection_count++;
         source_search_start++;
         destination_search_start++;
         on_intersection(cur_edge_src);
-        // printf("Triangle: %i, %i, %i\n", source, destination, cur_edge_src);
       } else if (cur_edge_src > cur_edge_dst) {
         destination_search_start++;
       } else {

--- a/include/gunrock/graph/graph.hxx
+++ b/include/gunrock/graph/graph.hxx
@@ -87,11 +87,7 @@ class graph_t : public graph_view_t... {
   /**
    * @brief Default constructor for the graph.
    */
-  __host__ __device__ graph_t()
-      : number_of_vertices(0),
-        number_of_edges(0),
-        properties(),
-        graph_view_t()... {}
+  __host__ __device__ graph_t() : properties(), graph_view_t()... {}
 
   /**
    * @brief Get the number of vertices in the graph. Callable from both host and

--- a/include/gunrock/graph/graph.hxx
+++ b/include/gunrock/graph/graph.hxx
@@ -99,9 +99,10 @@ class graph_t : public graph_view_t... {
    *
    * @return vertex_type number of vertices in the graph.
    */
+  template <class input_view_t = default_view_t>
   __host__ __device__ __forceinline__ const vertex_type
   get_number_of_vertices() const {
-    return number_of_vertices;
+    return input_view_t::get_number_of_vertices();
   }
 
   /**
@@ -110,9 +111,10 @@ class graph_t : public graph_view_t... {
    *
    * @return edge_type number of edges in the graph.
    */
+  template <class input_view_t = default_view_t>
   __host__ __device__ __forceinline__ const edge_type
   get_number_of_edges() const {
-    return number_of_edges;
+    return input_view_t::get_number_of_edges();
   }
 
   /**
@@ -190,8 +192,6 @@ class graph_t : public graph_view_t... {
   __host__ __device__ void set(vertex_type const& _number_of_vertices,
                                edge_type const& _number_of_edges,
                                args_t... args) {
-    this->number_of_vertices = _number_of_vertices;
-    this->number_of_edges = _number_of_edges;
     input_view_t::set(_number_of_vertices, _number_of_edges, args...);
   }
 
@@ -316,8 +316,6 @@ class graph_t : public graph_view_t... {
   static constexpr std::size_t number_of_formats_inherited =
       std::tuple_size_v<true_view_t>;
 
-  vertex_type number_of_vertices;
-  edge_type number_of_edges;
   graph_properties_t properties;
 
 };  // namespace graph

--- a/unittests/algorithms/tc.cuh
+++ b/unittests/algorithms/tc.cuh
@@ -1,0 +1,55 @@
+/**
+ * @file tc.cuh
+ * @author Muhammad A. Awad (awad@ucdavis.edu)
+ * @brief Unit test for the triangle counting algorithm.
+ * @version 0.1
+ * @date 2022-17-06
+ *
+ * @copyright Copyright (c) 2022
+ *
+ */
+
+#include <gunrock/graph/graph.hxx>
+#include <gunrock/formats/formats.hxx>
+#include <gunrock/algorithms/tc.hxx>
+
+using namespace gunrock;
+using namespace memory;
+
+TEST(algorithm, tc) {
+  // CSR Matrix Representation
+  // V            = [ 1 1 1 1 ]
+  // ROW_OFFSETS  = [ 0 3 5 8 10 ]
+  // COL_INDEX    = [ 1 2 3 0 2 0 1 3 0 2]
+
+  using vertex_t = int;
+  using edge_t = int;
+  using weight_t = int;
+
+  vertex_t number_of_rows = 4, number_of_columns = 4;
+  edge_t number_of_nonzeros = 10;
+  thrust::device_vector<edge_t> Ap = std::vector{0, 3, 5, 8, 10};
+  thrust::device_vector<vertex_t> Aj =
+      std::vector{1, 2, 3, 0, 2, 0, 1, 3, 0, 2};
+  thrust::device_vector<weight_t> Ax(number_of_nonzeros, 0);
+
+  auto G = graph::build::from_csr<memory_space_t::device, graph::view_t::csr>(
+      number_of_rows, number_of_columns, number_of_nonzeros, Ap.data().get(),
+      Aj.data().get(), Ax.data().get());
+
+  std::size_t total_triangles = 0;
+  thrust::device_vector<vertex_t> d_triangles_count(number_of_rows, 0);
+  tc::run(G, true, d_triangles_count.data().get(), &total_triangles);
+
+  thrust::host_vector<vertex_t> h_triangles_count(d_triangles_count);
+
+  std::size_t reference_total_triangles = 6;
+  thrust::host_vector<vertex_t> reference_traingles_count =
+      std::vector{2, 1, 2, 1};
+
+  for (std::size_t v = 0; v < number_of_rows; v++) {
+    EXPECT_EQ(h_triangles_count[v], reference_traingles_count[v]);
+  }
+
+  EXPECT_EQ(total_triangles, reference_total_triangles);
+}

--- a/unittests/algorithms/tc.cuh
+++ b/unittests/algorithms/tc.cuh
@@ -1,6 +1,6 @@
 /**
  * @file tc.cuh
- * @author Muhammad A. Awad (awad@ucdavis.edu)
+ * @author Muhammad A. Awad (mawad@ucdavis.edu)
  * @brief Unit test for the triangle counting algorithm.
  * @version 0.1
  * @date 2022-17-06

--- a/unittests/unittests.hxx
+++ b/unittests/unittests.hxx
@@ -41,3 +41,5 @@
 // #include "io/matrix_market.cuh"
 #include "io/smtx.cuh"
 // #include "io/mtxbin.cuh"
+
+#include "algorithms/tc.cuh"


### PR DESCRIPTION
This PR adds:
- Triangle Counting algorithm
- Optional argument (`bound_t bounds = bound_t::upper`) in binary search to switch between lower and upper bounds searches
- Intersection count implementation in CSR (`get_intersection_count`)