### PR TITLE
WIP: hipify essentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ externals/*
 
 # Ignore slurm files
 slurm-*.out
+
+# HIP
+*.prehip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(ESSENTIALS_VERSION "${ESSENTIALS_VERSION_MAJOR}.${ESSENTIALS_VERSION_MINOR}.
 
 project(essentials
   VERSION ${ESSENTIALS_VERSION}
-  LANGUAGES CXX C CUDA
+  LANGUAGES CXX C CUDA HIP
 )
 
 # begin /* Dependencies directory */
@@ -34,7 +34,7 @@ set(PROJECT_DEPS_DIR externals)
 # end /* Dependencies directory */
 
 # begin /* Include cmake modules */
-include(${PROJECT_SOURCE_DIR}/cmake/FetchThrustCUB.cmake)
+#include(${PROJECT_SOURCE_DIR}/cmake/FetchThrustCUB.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/FetchModernGPU.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/FetchCXXOpts.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/FetchRapidJSON.cmake)
@@ -109,22 +109,25 @@ set(ESSENTIALS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(essentials
   INTERFACE ${ESSENTIALS_INCLUDE_DIR}
   INTERFACE ${CXXOPTS_INCLUDE_DIR}
-  INTERFACE ${THRUST_INCLUDE_DIR}
-  INTERFACE ${CUB_INCLUDE_DIR}
+  # INTERFACE ${THRUST_INCLUDE_DIR}
+  #INTERFACE ${CUB_INCLUDE_DIR}
   INTERFACE ${MODERNGPU_INCLUDE_DIR}
   INTERFACE ${RAPIDJSON_INCLUDE_DIR}
   INTERFACE ${NHLOMANN_JSON_INCLUDE_DIR}
-  INTERFACE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+  #INTERFACE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
 )
 
 ####################################################
 ############ TARGET LINK LIBRARIES #################
 ####################################################
 target_link_libraries(essentials
-  INTERFACE curand
-  INTERFACE cuda
-  INTERFACE cusparse
+#  INTERFACE curand
+#  INTERFACE cuda
+#  INTERFACE cusparse
+   INTERFACE rocrand
+   INTERFACE hipsparse
 )
+target_link_directories(essentials INTERFACE /opt/rocm/lib)
 
 ####################################################
 ################# TARGET SOURCES ###################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # ./cmake-[x.xx.x]-linux-x86_64.sh
 # sudo mv cmake-[x.xx.x]-linux-x86_64 /opt/cmake
 # sudo ln -s /opt/cmake/bin/* /usr/local/bin/
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
 
 # begin /* Update Essentials version */
 set(ESSENTIALS_VERSION_MAJOR 2)
@@ -26,7 +26,7 @@ set(ESSENTIALS_VERSION "${ESSENTIALS_VERSION_MAJOR}.${ESSENTIALS_VERSION_MINOR}.
 
 project(essentials
   VERSION ${ESSENTIALS_VERSION}
-  LANGUAGES CXX C CUDA HIP
+  LANGUAGES CXX C HIP
 )
 
 # begin /* Dependencies directory */
@@ -35,7 +35,7 @@ set(PROJECT_DEPS_DIR externals)
 
 # begin /* Include cmake modules */
 #include(${PROJECT_SOURCE_DIR}/cmake/FetchThrustCUB.cmake)
-include(${PROJECT_SOURCE_DIR}/cmake/FetchModernGPU.cmake)
+#include(${PROJECT_SOURCE_DIR}/cmake/FetchModernGPU.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/FetchCXXOpts.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/FetchRapidJSON.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/FetchNlohmannJson.cmake)
@@ -111,7 +111,7 @@ target_include_directories(essentials
   INTERFACE ${CXXOPTS_INCLUDE_DIR}
   # INTERFACE ${THRUST_INCLUDE_DIR}
   #INTERFACE ${CUB_INCLUDE_DIR}
-  INTERFACE ${MODERNGPU_INCLUDE_DIR}
+  #INTERFACE ${MODERNGPU_INCLUDE_DIR}
   INTERFACE ${RAPIDJSON_INCLUDE_DIR}
   INTERFACE ${NHLOMANN_JSON_INCLUDE_DIR}
   #INTERFACE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}

--- a/cmake/FetchModernGPU.cmake
+++ b/cmake/FetchModernGPU.cmake
@@ -8,8 +8,8 @@ set(FETCHCONTENT_BASE_DIR ${FC_BASE})
 
 FetchContent_Declare(
     moderngpu
-    GIT_REPOSITORY https://github.com/moderngpu/moderngpu.git
-    GIT_TAG        master
+    GIT_REPOSITORY https://github.com/crozhon/moderngpu.git
+    GIT_TAG        hip
 )
 
 FetchContent_GetProperties(moderngpu)

--- a/examples/algorithms/bfs/CMakeLists.txt
+++ b/examples/algorithms/bfs/CMakeLists.txt
@@ -1,21 +1,29 @@
-# begin /* Set the application name. */
-set(APPLICATION_NAME bfs)
-# end /* Set the application name. */
+## begin /* Set the application name. */
+#set(APPLICATION_NAME bfs)
+## end /* Set the application name. */
+#
+## begin /* Add CUDA executables */
+#add_executable(${APPLICATION_NAME})
+#
+#set(SOURCE_LIST 
+#    ${APPLICATION_NAME}.cu
+#)
+#
+#target_sources(${APPLICATION_NAME} PRIVATE ${SOURCE_LIST})
+#target_link_libraries(${APPLICATION_NAME} PRIVATE essentials)
+#get_target_property(ESSENTIALS_ARCHITECTURES essentials CUDA_ARCHITECTURES)
+#set_target_properties(${APPLICATION_NAME} 
+#    PROPERTIES 
+#        CUDA_ARCHITECTURES ${ESSENTIALS_ARCHITECTURES}
+#) # XXX: Find a better way to inherit essentials properties.
+#
+#message(STATUS "Example Added: ${APPLICATION_NAME}")
+## end /* Add CUDA executables */
+#
 
-# begin /* Add CUDA executables */
-add_executable(${APPLICATION_NAME})
-
-set(SOURCE_LIST 
-    ${APPLICATION_NAME}.cu
-)
-
-target_sources(${APPLICATION_NAME} PRIVATE ${SOURCE_LIST})
-target_link_libraries(${APPLICATION_NAME} PRIVATE essentials)
-get_target_property(ESSENTIALS_ARCHITECTURES essentials CUDA_ARCHITECTURES)
-set_target_properties(${APPLICATION_NAME} 
-    PROPERTIES 
-        CUDA_ARCHITECTURES ${ESSENTIALS_ARCHITECTURES}
-) # XXX: Find a better way to inherit essentials properties.
-
-message(STATUS "Example Added: ${APPLICATION_NAME}")
-# end /* Add CUDA executables */
+add_executable(bfs-HIP bfs.cu)
+set_source_files_properties(bfs.cu PROPERTIES LANGUAGE HIP)
+target_include_directories(bfs-HIP SYSTEM PRIVATE /opt/rocm/include)
+target_link_libraries(bfs-HIP PRIVATE essentials)
+target_include_directories(bfs-HIP SYSTEM BEFORE PRIVATE ${CMAKE_SOURCE_DIR}/externals/rocthrust-src)
+add_compile_definitions(__HIP_PLATFORM_AMD__)

--- a/include/gunrock/algorithms/bfs.hxx
+++ b/include/gunrock/algorithms/bfs.hxx
@@ -85,11 +85,12 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
 
     auto single_source = P->param.single_source;
     auto distances = P->result.distances;
+    auto d_distances = thrust::device_pointer_cast(P->result.distances).get();
     auto visited = P->visited.data().get();
 
     auto iteration = this->iteration;
 
-    auto search = [distances, single_source, iteration] __host__ __device__(
+    auto search = [d_distances, single_source, iteration] __host__ __device__(
                       vertex_t const& source,    // ... source
                       vertex_t const& neighbor,  // neighbor
                       edge_t const& edge,        // edge
@@ -109,7 +110,7 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
 
       // Simpler logic for the above.
       auto old_distance =
-          math::atomic::min(&distances[neighbor], iteration + 1);
+          math::atomic::min(d_distances + neighbor, iteration + 1);
       return (iteration + 1 < old_distance);
     };
 

--- a/include/gunrock/algorithms/experimental/async/bfs.hxx
+++ b/include/gunrock/algorithms/experimental/async/bfs.hxx
@@ -1,3 +1,4 @@
+#include "hip/hip_runtime.h"
 #pragma once
 
 #include <gunrock/algorithms/algorithms.hxx>
@@ -84,7 +85,7 @@ struct enactor_t : async::enactor_t<problem_t> {
 
     // !! Queues creates it's own streams.  But I think we should at least
     //    synchronizing the to the `context` stream?
-    _push_one<<<1, 1>>>(q, P->param.single_source);
+    hipLaunchKernelGGL(_push_one, 1, 1, 0, 0, q, P->param.single_source);
   }
 
   // !! Breaks w/ standard essentials (mildly...)

--- a/include/gunrock/algorithms/sort/radix_sort.hxx
+++ b/include/gunrock/algorithms/sort/radix_sort.hxx
@@ -43,10 +43,10 @@ void sort_keys(type_t* keys,
                order_t order = order_t::ascending,
                gcuda::stream_t stream = 0) {
   if (order == order_t::ascending)
-    thrust::sort(thrust::cuda::par.on(stream), keys, keys + num_items,
+    thrust::sort(thrust::hip::par.on(stream), keys, keys + num_items,
                  thrust::less<type_t>());
   else
-    thrust::sort(thrust::cuda::par.on(stream), keys, keys + num_items,
+    thrust::sort(thrust::hip::par.on(stream), keys, keys + num_items,
                  thrust::greater<type_t>());
 }
 

--- a/include/gunrock/container/experimental/async/queue.hxx
+++ b/include/gunrock/container/experimental/async/queue.hxx
@@ -1,13 +1,9 @@
 #pragma once
-
 #ifdef __HIP__
 inline __device__ unsigned int __activemask() {
-  unsigned int mask;
-  asm volatile("activemask.b32 %0;" : "=r"(mask));
-  return mask;
+    return __ballot(1);
 }
 #endif
-
 #include "hip/hip_runtime.h"
 
 #include <inttypes.h>

--- a/include/gunrock/container/experimental/async/queue.hxx
+++ b/include/gunrock/container/experimental/async/queue.hxx
@@ -1,5 +1,15 @@
 #pragma once
 
+#ifdef __HIP__
+inline __device__ unsigned int __activemask() {
+  unsigned int mask;
+  asm volatile("activemask.b32 %0;" : "=r"(mask));
+  return mask;
+}
+#endif
+
+#include "hip/hip_runtime.h"
+
 #include <inttypes.h>
 #include <limits>
 #include <assert.h>
@@ -56,18 +66,18 @@ struct Queue {
 
   __host__ void release() {
     if (queue != NULL)
-      cudaFree(queue);
+      hipFree(queue);
   }
 
   __host__ void reset() {
-    cudaMemset((void*)queue, -1, sizeof(T) * capacity);
-    cudaMemset((void*)start, 0, sizeof(CounterT));
-    cudaMemset((void*)start_alloc, 0, sizeof(CounterT));
-    cudaMemset((void*)end, 0, sizeof(CounterT));
-    cudaMemset((void*)end_alloc, 0, sizeof(CounterT));
-    cudaMemset((void*)end_max, 0, sizeof(CounterT));
-    cudaMemset((void*)end_count, 0, sizeof(CounterT));
-    cudaMemset((void*)stop, 0, sizeof(CounterT));
+    hipMemset((void*)queue, -1, sizeof(T) * capacity);
+    hipMemset((void*)start, 0, sizeof(CounterT));
+    hipMemset((void*)start_alloc, 0, sizeof(CounterT));
+    hipMemset((void*)end, 0, sizeof(CounterT));
+    hipMemset((void*)end_alloc, 0, sizeof(CounterT));
+    hipMemset((void*)end_max, 0, sizeof(CounterT));
+    hipMemset((void*)end_count, 0, sizeof(CounterT));
+    hipMemset((void*)stop, 0, sizeof(CounterT));
   }
 
   __forceinline__ __device__ T get(CounterT) const;
@@ -77,7 +87,7 @@ struct Queue {
   template <typename Functor, typename... Args>
   __host__ void launch_thread(int numBlock,
                               int numThread,
-                              cudaStream_t stream,
+                              hipStream_t stream,
                               Functor f,
                               Args... arg);
 };
@@ -175,10 +185,10 @@ template <typename T, typename CounterT>
 template <typename Functor, typename... Args>
 void Queue<T, CounterT>::launch_thread(int numBlock,
                                        int numThread,
-                                       cudaStream_t stream,
+                                       hipStream_t stream,
                                        Functor f,
                                        Args... arg) {
-  _launch_thread<<<numBlock, numThread, 0, stream>>>(*this, f, arg...);
+  hipLaunchKernelGGL(_launch_thread, numBlock, numThread, 0, stream, *this, f, arg...);
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -201,7 +211,7 @@ struct Queues {
 
   uint32_t min_iter;
   Queue<T, CounterT>* worklist;
-  cudaStream_t* streams;
+  hipStream_t* streams;
 
   __host__ void init(CounterT _capacity,
                      uint32_t _num_q = 8,
@@ -216,14 +226,14 @@ struct Queues {
 
     // Allocate queue memory
     auto queue_size = sizeof(T) * capacity * num_queues;
-    cudaMalloc(&queue, queue_size);
-    cudaMemset((void*)queue, -1, queue_size);
+    hipMalloc(&queue, queue_size);
+    hipMemset((void*)queue, -1, queue_size);
 
     // Allocate counter memory
     auto counter_size =
         sizeof(CounterT) * num_counters * num_queues * PADDING_SIZE;
-    cudaMalloc(&counters, counter_size);
-    cudaMemset((void*)counters, 0, counter_size);
+    hipMalloc(&counters, counter_size);
+    hipMemset((void*)counters, 0, counter_size);
 
     start = &counters[0 * num_queues * PADDING_SIZE];
     start_alloc = &counters[1 * num_queues * PADDING_SIZE];
@@ -235,7 +245,7 @@ struct Queues {
 
     worklist =
         (Queue<T, CounterT>*)malloc(sizeof(Queue<T, CounterT>) * num_queues);
-    streams = (cudaStream_t*)malloc(sizeof(cudaStream_t) * num_queues);
+    streams = (hipStream_t*)malloc(sizeof(hipStream_t) * num_queues);
 
     for (uint64_t q_id = 0; q_id < num_queues; q_id++) {
       auto q_offset = q_id * capacity;
@@ -245,15 +255,15 @@ struct Queues {
           start_alloc + c_offset, end_alloc + c_offset, end_max + c_offset,
           end_count + c_offset, stop, num_queues, q_id, min_iter);
 
-      cudaStreamCreateWithFlags(&streams[q_id], cudaStreamNonBlocking);
+      hipStreamCreateWithFlags(&streams[q_id], hipStreamNonBlocking);
     }
   }
 
   __host__ void release() {
     if (queue != NULL)
-      cudaFree(queue);
+      hipFree(queue);
     if (counters != NULL)
-      cudaFree((void*)counters);
+      hipFree((void*)counters);
     if (streams != NULL)
       free(streams);
     if (worklist != NULL)
@@ -321,12 +331,12 @@ struct Queues {
     for (int i = 0; i < num_queues; i++)
       worklist[i].reset();
 
-    cudaDeviceSynchronize();
+    hipDeviceSynchronize();
   }
 
   __host__ void sync() {
     for (int i = 0; i < num_queues; i++)
-      cudaStreamSynchronize(streams[i]);
+      hipStreamSynchronize(streams[i]);
   }
 };
 

--- a/include/gunrock/cuda/context.hxx
+++ b/include/gunrock/cuda/context.hxx
@@ -1,3 +1,4 @@
+#include "hip/hip_runtime.h"
 /**
  * @file context.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)
@@ -10,7 +11,6 @@
  */
 #pragma once
 
-#include <gunrock/cuda/device.hxx>
 #include <gunrock/cuda/device_properties.hxx>
 #include <gunrock/cuda/event_management.hxx>
 #include <gunrock/cuda/stream_management.hxx>
@@ -45,7 +45,7 @@ struct context_t {
   virtual gcuda::stream_t stream() = 0;
   virtual mgpu::standard_context_t* mgpu() = 0;
 
-  // cudaStreamSynchronize or cudaDeviceSynchronize for stream 0.
+  // hipStreamSynchronize or hipDeviceSynchronize for stream 0.
   virtual void synchronize() = 0;
   virtual gcuda::event_t event() = 0;
   virtual util::timer_t& timer() = 0;
@@ -74,14 +74,14 @@ class standard_context_t : public context_t {
   template <int dummy_arg = 0>
   void init() {
     gcuda::function_attributes_t attr;
-    error::error_t status = cudaFuncGetAttributes(&attr, dummy_k<0>);
+    error::error_t status = hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(dummy_k<0>));
     error::throw_if_exception(status);
     _ptx_version = gcuda::make_compute_capability(attr.ptxVersion);
 
-    cudaSetDevice(_ordinal);
-    cudaStreamCreateWithFlags(&_stream, cudaStreamNonBlocking);
-    cudaEventCreateWithFlags(&_event, cudaEventDisableTiming);
-    cudaGetDeviceProperties(&_props, _ordinal);
+    hipSetDevice(_ordinal);
+    hipStreamCreateWithFlags(&_stream, hipStreamNonBlocking);
+    hipEventCreateWithFlags(&_event, hipEventDisableTiming);
+    hipGetDeviceProperties(&_props, _ordinal);
 
     _mgpu_context = new mgpu::standard_context_t(false, _stream);
   }
@@ -92,12 +92,12 @@ class standard_context_t : public context_t {
     init();
   }
 
-  standard_context_t(cudaStream_t stream, gcuda::device_id_t device = 0)
+  standard_context_t(hipStream_t stream, gcuda::device_id_t device = 0)
       : context_t(), _ordinal(device), _mgpu_context(nullptr), _stream(stream) {
     init();
   }
 
-  ~standard_context_t() { cudaEventDestroy(_event); }
+  ~standard_context_t() { hipEventDestroy(_event); }
 
   virtual const gcuda::device_properties_t& props() const override {
     return _props;
@@ -117,7 +117,7 @@ class standard_context_t : public context_t {
 
   virtual void synchronize() override {
     error::error_t status =
-        _stream ? cudaStreamSynchronize(_stream) : cudaDeviceSynchronize();
+        _stream ? hipStreamSynchronize(_stream) : hipDeviceSynchronize();
     error::throw_if_exception(status);
   }
 
@@ -128,7 +128,7 @@ class standard_context_t : public context_t {
   virtual gcuda::device_id_t ordinal() { return _ordinal; }
 
   auto execution_policy() {
-    return thrust::cuda::par_nosync.on(this->stream());
+    return thrust::hip::par.on(this->stream());
   }
 
 };  // class standard_context_t
@@ -150,7 +150,7 @@ class multi_context_t {
 
   // Multiple devices with a user-provided stream
   multi_context_t(thrust::host_vector<gcuda::device_id_t> _devices,
-                  cudaStream_t _stream)
+                  hipStream_t _stream)
       : devices(_devices) {
     for (auto& device : devices) {
       standard_context_t* device_context =
@@ -168,7 +168,7 @@ class multi_context_t {
   }
 
   // Single device with a user-provided stream
-  multi_context_t(gcuda::device_id_t _device, cudaStream_t _stream)
+  multi_context_t(gcuda::device_id_t _device, hipStream_t _stream)
       : devices(1, _device) {
     for (auto& device : devices) {
       standard_context_t* device_context =
@@ -189,19 +189,19 @@ class multi_context_t {
     int num_gpus = size();
     for (int i = 0; i < num_gpus; i++) {
       auto ctx = get_context(i);
-      cudaSetDevice(ctx->ordinal());
+      hipSetDevice(ctx->ordinal());
 
       for (int j = 0; j < num_gpus; j++) {
         if (i == j)
           continue;
 
         auto ctx_peer = get_context(j);
-        cudaDeviceEnablePeerAccess(ctx_peer->ordinal(), 0);
+        hipDeviceEnablePeerAccess(ctx_peer->ordinal(), 0);
       }
     }
 
     auto ctx0 = get_context(0);
-    cudaSetDevice(ctx0->ordinal());
+    hipSetDevice(ctx0->ordinal());
   }
 };  // class multi_context_t
 

--- a/include/gunrock/cuda/detail/launch_kernels.hxx
+++ b/include/gunrock/cuda/detail/launch_kernels.hxx
@@ -1,3 +1,4 @@
+#include "hip/hip_runtime.h"
 /**
  * @file launch_kernels.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)

--- a/include/gunrock/cuda/device.hxx
+++ b/include/gunrock/cuda/device.hxx
@@ -18,7 +18,7 @@ typedef int device_id_t;
 namespace device {
 
 void set(gcuda::device_id_t device) {
-  cudaSetDevice(device);
+  hipSetDevice(device);
 }
 
 }  // namespace device

--- a/include/gunrock/cuda/device_properties.hxx
+++ b/include/gunrock/cuda/device_properties.hxx
@@ -16,7 +16,7 @@
 namespace gunrock {
 namespace gcuda {
 
-typedef cudaDeviceProp device_properties_t;
+typedef hipDeviceProp_t device_properties_t;
 
 struct compute_capability_t {
   unsigned major;
@@ -148,21 +148,21 @@ inline constexpr unsigned sm_registers(compute_capability_t capability) {
 
 /**
  * @brief Maximum amount of shared memory per SM.
- * @tparam sm3XCacheConfig cudaFuncCache enum representing the shared data
+ * @tparam sm3XCacheConfig hipFuncCache_t enum representing the shared data
  *                         cache configuration used when called on compute
  *                         capability 3.x
  * @param capability       Compute capability from which to get the result
  * \return unsigned
  * @todo Test if this function can be resolved at compile time
  */
-template <enum cudaFuncCache sm3XCacheConfig = cudaFuncCachePreferNone>
+template <enum hipFuncCache_t sm3XCacheConfig = hipFuncCachePreferNone>
 inline constexpr unsigned sm_max_shared_memory_bytes(
     compute_capability_t capability) {
   unsigned sm3XConfiguredSmem =
-      (sm3XCacheConfig == cudaFuncCachePreferNone)     ? 48 * KiB
-      : (sm3XCacheConfig == cudaFuncCachePreferShared) ? 48 * KiB
-      : (sm3XCacheConfig == cudaFuncCachePreferL1)     ? 16 * KiB
-      : (sm3XCacheConfig == cudaFuncCachePreferEqual)  ? 32 * KiB
+      (sm3XCacheConfig == hipFuncCachePreferNone)     ? 48 * KiB
+      : (sm3XCacheConfig == hipFuncCachePreferShared) ? 48 * KiB
+      : (sm3XCacheConfig == hipFuncCachePreferL1)     ? 16 * KiB
+      : (sm3XCacheConfig == hipFuncCachePreferEqual)  ? 32 * KiB
                                                        : 48 * KiB;
 
   return (capability >= 86) ? 100 * KiB :  // SM86+
@@ -197,28 +197,28 @@ inline constexpr unsigned shared_memory_banks() {
 
 /**
  * @brief Stride length (number of bytes per word) of shared memory in bytes.
- * @tparam sm3XSmemConfig cudaSharedMemConfig enum representing the shared
+ * @tparam sm3XSmemConfig hipSharedMemConfig enum representing the shared
  *                        memory bank size (stride) used when called on compute
  *                        capability 3.x
  * \return unsigned
  */
 template <
-    enum cudaSharedMemConfig sm3XSmemConfig = cudaSharedMemBankSizeDefault>
+    enum hipSharedMemConfig sm3XSmemConfig = hipSharedMemBankSizeDefault>
 inline constexpr unsigned shared_memory_bank_stride() {
   // The default config on 3.x is the same constant value for later archs
   // Only let 3.x be configurable if stride later becomes dependent on arch
-  return (sm3XSmemConfig == cudaSharedMemBankSizeDefault)     ? 1 << 2
-         : (sm3XSmemConfig == cudaSharedMemBankSizeFourByte)  ? 1 << 2
-         : (sm3XSmemConfig == cudaSharedMemBankSizeEightByte) ? 1 << 3
+  return (sm3XSmemConfig == hipSharedMemBankSizeDefault)     ? 1 << 2
+         : (sm3XSmemConfig == hipSharedMemBankSizeFourByte)  ? 1 << 2
+         : (sm3XSmemConfig == hipSharedMemBankSizeEightByte) ? 1 << 3
                                                               : 1 << 2;
 }
 
 void print(device_properties_t& prop) {
   device_id_t ordinal;
-  cudaGetDevice(&ordinal);
+  hipGetDevice(&ordinal);
 
   size_t freeMem, totalMem;
-  error::error_t status = cudaMemGetInfo(&freeMem, &totalMem);
+  error::error_t status = hipMemGetInfo(&freeMem, &totalMem);
   error::throw_if_exception(status);
 
   double memBandwidth =

--- a/include/gunrock/cuda/event_management.hxx
+++ b/include/gunrock/cuda/event_management.hxx
@@ -14,7 +14,7 @@
 namespace gunrock {
 namespace gcuda {
 
-typedef cudaEvent_t event_t;
+typedef hipEvent_t event_t;
 
 }  // namespace gcuda
 }  // namespace gunrock

--- a/include/gunrock/cuda/function.hxx
+++ b/include/gunrock/cuda/function.hxx
@@ -13,7 +13,7 @@
 namespace gunrock {
 namespace gcuda {
 
-typedef cudaFuncAttributes function_attributes_t;
+typedef hipFuncAttributes function_attributes_t;
 
 }  // namespace gcuda
 }  // namespace gunrock

--- a/include/gunrock/cuda/global.hxx
+++ b/include/gunrock/cuda/global.hxx
@@ -10,6 +10,8 @@
  */
 
 #pragma once
+#include <hip/hip_runtime.h>
+
 namespace gunrock {
 namespace gcuda {
 

--- a/include/gunrock/cuda/launch_box.hxx
+++ b/include/gunrock/cuda/launch_box.hxx
@@ -44,7 +44,7 @@ struct dimensions_t {
   __host__ __device__ operator dim3(void) const { return uint3{x, y, z}; }
 #else
   __host__ __device__ constexpr operator dim3(void) const {
-    return uint3{x, y, z};
+    return dim3{x, y, z};
   }
 #endif
 };
@@ -299,7 +299,7 @@ struct launch_box_t : public select_launch_params_t<lp_v...> {
     void* argument_ptrs[non_zero_num_params];
     detail::for_each_argument_address(argument_ptrs,
                                       ::std::forward<args_t>(args)...);
-    cudaLaunchCooperativeKernel<func_t>(
+    hipLaunchCooperativeKernel<func_t>(
         &f, params_t::grid_dimensions, params_t::block_dimensions,
         argument_ptrs, params_t::shared_memory_bytes, context.stream());
   }
@@ -347,11 +347,11 @@ inline float occupancy(func_t kernel) {
   int max_active_blocks;
   int block_size = launch_box_t::block_dimensions_t::size();
   int device;
-  cudaDeviceProp props;
+  hipDeviceProp_t props;
 
-  cudaGetDevice(&device);
-  cudaGetDeviceProperties(&props, device);
-  error::error_t status = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+  hipGetDevice(&device);
+  hipGetDeviceProperties(&props, device);
+  error::error_t status = hipOccupancyMaxActiveBlocksPerMultiprocessor(
       &max_active_blocks, kernel, block_size, (size_t)0);
   error::throw_if_exception(status);
   float occupancy = (max_active_blocks * block_size / props.warpSize) /

--- a/include/gunrock/cuda/stream_management.hxx
+++ b/include/gunrock/cuda/stream_management.hxx
@@ -13,7 +13,7 @@
 namespace gunrock {
 namespace gcuda {
 
-typedef cudaStream_t stream_t;
+typedef hipStream_t stream_t;
 
 }  // namespace gcuda
 }  // namespace gunrock

--- a/include/gunrock/error.hxx
+++ b/include/gunrock/error.hxx
@@ -2,7 +2,7 @@
 
 #include <exception>
 #include <string>
-#include <cuda_runtime_api.h>
+#include <hip/hip_runtime_api.h>
 
 namespace gunrock {
 
@@ -12,7 +12,7 @@ namespace gunrock {
  */
 namespace error {
 
-typedef cudaError_t error_t;
+typedef hipError_t error_t;
 
 /**
  * @brief Exception class for errors in device code.
@@ -22,7 +22,7 @@ struct exception_t : std::exception {
   std::string report;
 
   exception_t(error_t _status, std::string _message = "") {
-    report = cudaGetErrorString(_status) + std::string("\t: ") + _message;
+    report = hipGetErrorString(_status) + std::string("\t: ") + _message;
   }
 
   exception_t(std::string _message = "") { report = _message; }
@@ -30,13 +30,13 @@ struct exception_t : std::exception {
 };
 
 /**
- * @brief Throw an exception if the given error code is not cudaSuccess.
+ * @brief Throw an exception if the given error code is not hipSuccess.
  *
- * @param status error_t error code (equivalent to cudaError_t).
+ * @param status error_t error code (equivalent to hipError_t).
  * @param message custom message to be appended to the error message.
  */
 inline void throw_if_exception(error_t status, std::string message = "") {
-  if (status != cudaSuccess)
+  if (status != hipSuccess)
     throw exception_t(status, message);
 }
 

--- a/include/gunrock/framework/frontier/experimental/boolmap_frontier.hxx
+++ b/include/gunrock/framework/frontier/experimental/boolmap_frontier.hxx
@@ -145,7 +145,7 @@ class boolmap_frontier_t {
    */
   void fill(type_t const value, gcuda::stream_t stream = 0) {
     if (value != 0 || value != 1)
-      error::throw_if_exception(cudaErrorUnknown,
+      error::throw_if_exception(hipErrorUnknown,
                                 "Boolmap only supports 1 or 0 as fill value.");
 
     thrust::fill(thrust::cuda::par.on(stream), this->begin(), this->end(),

--- a/include/gunrock/framework/frontier/vector_frontier.hxx
+++ b/include/gunrock/framework/frontier/vector_frontier.hxx
@@ -174,7 +174,7 @@ class vector_frontier_t {
    * @param stream
    */
   void fill(type_t const value, gcuda::stream_t stream = 0) {
-    thrust::fill(thrust::cuda::par.on(stream), this->begin(), this->end(),
+    thrust::fill(thrust::hip::par.on(stream), this->begin(), this->end(),
                  value);
   }
 
@@ -198,7 +198,7 @@ class vector_frontier_t {
     // Set the new number of elements.
     this->set_number_of_elements(size);
 
-    thrust::sequence(thrust::cuda::par.on(stream), this->begin(), this->end(),
+    thrust::sequence(thrust::hip::par.on(stream), this->begin(), this->end(),
                      initial_value);
   }
 

--- a/include/gunrock/framework/operators/advance/advance.hxx
+++ b/include/gunrock/framework/operators/advance/advance.hxx
@@ -118,12 +118,12 @@ void execute(graph_t& G,
       block_mapped::execute<direction, input_type, output_type>(
           G, op, *input, *output, *context0);
     } else {
-      error::throw_if_exception(cudaErrorUnknown,
+      error::throw_if_exception(hipErrorUnknown,
                                 "Advance type not supported.");
     }
 
   } else {
-    error::throw_if_exception(cudaErrorUnknown,
+    error::throw_if_exception(hipErrorUnknown,
                               "`context.size() != 1` not supported");
   }
 }

--- a/include/gunrock/framework/operators/advance/block_mapped.hxx
+++ b/include/gunrock/framework/operators/advance/block_mapped.hxx
@@ -1,3 +1,4 @@
+#include "hip/hip_runtime.h"
 /**
  * @file block_mapped.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)
@@ -19,8 +20,8 @@
 #include <thrust/transform_scan.h>
 #include <thrust/iterator/discard_iterator.h>
 
-#include <cub/block/block_load.cuh>
-#include <cub/block/block_scan.cuh>
+#include <hipcub/block/block_load.hpp>
+#include <hipcub/block/block_scan.hpp>
 
 namespace gunrock {
 namespace operators {
@@ -49,7 +50,7 @@ __global__ void __launch_bounds__(THREADS_PER_BLOCK, 2)
   using type_t = frontier_t;
 
   // Specialize Block Scan for 1D block of THREADS_PER_BLOCK.
-  using block_scan_t = cub::BlockScan<edge_t, THREADS_PER_BLOCK>;
+  using block_scan_t = hipcub::BlockScan<edge_t, THREADS_PER_BLOCK>;
 
   auto global_idx = gcuda::thread::global::id::x();
   auto local_idx = gcuda::thread::local::id::x();

--- a/include/gunrock/framework/operators/advance/helpers.hxx
+++ b/include/gunrock/framework/operators/advance/helpers.hxx
@@ -65,7 +65,7 @@ std::size_t compute_output_offsets(graph_t& G,
   };
 
   auto new_length = thrust::transform_exclusive_scan(
-      thrust::cuda::par.on(context.stream()),          // execution policy
+      thrust::hip::par.on(context.stream()),          // execution policy
       thrust::make_counting_iterator<std::size_t>(0),  // input iterator: first
       thrust::make_counting_iterator<std::size_t>(total_elems +
                                                   1),  // input iterator: last
@@ -133,7 +133,7 @@ std::size_t compute_output_length(graph_t& G,
   };
 
   auto new_length = thrust::transform_reduce(
-      thrust::cuda::par.on(context.stream()),          // execution policy
+      thrust::hip::par.on(context.stream()),          // execution policy
       thrust::make_counting_iterator<std::size_t>(0),  // input iterator: first
       thrust::make_counting_iterator<std::size_t>(
           total_elems),       // input iterator: last

--- a/include/gunrock/framework/operators/advance/merge_path.hxx
+++ b/include/gunrock/framework/operators/advance/merge_path.hxx
@@ -39,7 +39,7 @@ void execute(graph_t& G,
              work_tiles_t& segments,
              gcuda::standard_context_t& context) {
   if constexpr (direction == advance_direction_t::optimized) {
-    error::throw_if_exception(cudaErrorUnknown,
+    error::throw_if_exception(hipErrorUnknown,
                               "Direction-optimized not yet implemented.");
 
     // Direction-Optimized advance is supported using CSR and CSC graph
@@ -49,7 +49,7 @@ void execute(graph_t& G,
     using find_csc_t = typename graph_t::graph_csc_view_t;
     if (!(G.template contains_representation<find_csr_t>() &&
           G.template contains_representation<find_csc_t>())) {
-      error::throw_if_exception(cudaErrorUnknown,
+      error::throw_if_exception(hipErrorUnknown,
                                 "CSR and CSC sparse-matrix representations "
                                 "required for direction-optimized advance.");
     }

--- a/include/gunrock/framework/operators/advance/merge_path.hxx
+++ b/include/gunrock/framework/operators/advance/merge_path.hxx
@@ -11,15 +11,12 @@
 
 #pragma once
 
+
+#include <cassert>
 #include <gunrock/util/math.hxx>
 #include <gunrock/cuda/context.hxx>
 
 #include <gunrock/framework/operators/configs.hxx>
-
-// XXX: Replace these later
-#include <moderngpu/transform.hxx>
-#include <moderngpu/kernel_scan.hxx>
-#include <moderngpu/kernel_load_balance.hxx>
 
 namespace gunrock {
 namespace operators {
@@ -108,9 +105,7 @@ void execute(graph_t& G,
   int end = (input_type == advance_io_type_t::graph)
                 ? G.get_number_of_vertices()
                 : input->get_number_of_elements();
-  mgpu::transform_lbs(neighbors_expand, size_of_output,
-                      thrust::raw_pointer_cast(segments.data()), end,
-                      *(context.mgpu()));
+  assert(false);
 }
 }  // namespace merge_path
 }  // namespace advance

--- a/include/gunrock/framework/operators/advance/merge_path_v2.hxx
+++ b/include/gunrock/framework/operators/advance/merge_path_v2.hxx
@@ -1,3 +1,4 @@
+#include "hip/hip_runtime.h"
 /**
  * @file merge_path_v2.hxx
  * @author Muhammad Osama (mosama@ucdavis.edu)

--- a/include/gunrock/framework/operators/filter/bypass.hxx
+++ b/include/gunrock/framework/operators/filter/bypass.hxx
@@ -37,7 +37,7 @@ void execute(graph_t& G,
 
   // Filter with bypass
   thrust::transform(
-      thrust::cuda::par.on(context.stream()),          // execution policy
+      thrust::hip::par.on(context.stream()),          // execution policy
       thrust::make_counting_iterator<std::size_t>(0),  // input iterator: first
       thrust::make_counting_iterator<std::size_t>(end),  // input iterator: last
       output->begin(),                                   // output iterator

--- a/include/gunrock/framework/operators/filter/compact.hxx
+++ b/include/gunrock/framework/operators/filter/compact.hxx
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <moderngpu/kernel_compact.hxx>
 #include <gunrock/framework/operators/configs.hxx>
 
 namespace gunrock {
@@ -17,23 +16,8 @@ void execute(graph_t& G,
   using vertex_t = typename graph_t::vertex_type;
   using size_type = decltype(input->get_number_of_elements());
 
-  auto compact = mgpu::transform_compact(input->get_number_of_elements(),
-                                         *(context.mgpu()));
-  auto input_data = input->data();
-  int stream_count = compact.upsweep([=] __device__(size_type idx) {
-    auto item = input_data[idx];
-    // if input item is valid, process the lambda, otherwise return false.
-    return gunrock::util::limits::is_valid(item) ? op(item) : false;
-  });
-
-  if (output->get_capacity() < stream_count)
-    output->reserve(stream_count);
-  output->set_number_of_elements(stream_count);
-
-  auto output_data = output->data();
-  compact.downsweep([=] __device__(size_type dest_idx, size_type source_idx) {
-    output_data[dest_idx] = input_data[source_idx];
-  });
+  assert(false);
+  return;
 }
 }  // namespace compact
 }  // namespace filter

--- a/include/gunrock/framework/operators/filter/filter.hxx
+++ b/include/gunrock/framework/operators/filter/filter.hxx
@@ -77,10 +77,10 @@ void execute(graph_t& G,
     } else if (alg_type == filter_algorithm_t::remove) {
       remove::execute(G, op, input, output, *single_context);
     } else {
-      error::throw_if_exception(cudaErrorUnknown, "Filter type not supported.");
+      error::throw_if_exception(hipErrorUnknown, "Filter type not supported.");
     }
   } else {
-    error::throw_if_exception(cudaErrorUnknown,
+    error::throw_if_exception(hipErrorUnknown,
                               "`context.size() != 1` not supported");
   }
 }

--- a/include/gunrock/framework/operators/filter/predicated.hxx
+++ b/include/gunrock/framework/operators/filter/predicated.hxx
@@ -27,7 +27,7 @@ void execute(graph_t& G,
 
   // Copy w/ predicate!
   auto new_length = thrust::copy_if(
-      thrust::cuda::par.on(context.stream()),  // execution policy
+      thrust::hip::par.on(context.stream()),  // execution policy
       input->begin(),                          // input iterator: begin
       input->end(),                            // input iterator: end
       output->begin(),                         // output iterator

--- a/include/gunrock/framework/operators/filter/remove.hxx
+++ b/include/gunrock/framework/operators/filter/remove.hxx
@@ -26,7 +26,7 @@ void execute(graph_t& G,
 
   // Copy w/ predicate!
   auto new_length = thrust::remove_copy_if(
-      thrust::cuda::par.on(context.stream()),  // execution policy
+      thrust::hip::par.on(context.stream()),  // execution policy
       input->begin(),                          // input iterator: begin
       input->end(),                            // input iterator: end
       output->begin(),                         // output iterator: begin

--- a/include/gunrock/framework/operators/for/for.hxx
+++ b/include/gunrock/framework/operators/for/for.hxx
@@ -32,7 +32,7 @@ execute(frontier_t& f, func_t op, gcuda::multi_context_t& context) {
   using type_t = typename frontier_t::type_t;
   auto single_context = context.get_context(0);
   /// TODO: use get and set frontier elements instead.
-  thrust::for_each(thrust::cuda::par.on(single_context->stream()),
+  thrust::for_each(thrust::hip::par.on(single_context->stream()),
                    f.begin(),  // Begin: 0
                    f.end(),    // End: # of V/E
                    [=] __device__(type_t const& x) {
@@ -76,7 +76,7 @@ execute(graph_t& G, func_t op, gcuda::multi_context_t& context) {
   switch (type) {
     case parallel_for_each_t::weight:
       thrust::for_each(
-          thrust::cuda::par.on(single_context->stream()),
+          thrust::hip::par.on(single_context->stream()),
           thrust::make_counting_iterator<index_t>(0),     // Begin: 0
           thrust::make_counting_iterator<index_t>(size),  // End: # of V/E
           [=] __device__(index_t const& x) {
@@ -86,7 +86,7 @@ execute(graph_t& G, func_t op, gcuda::multi_context_t& context) {
       break;
     default:
       thrust::for_each(
-          thrust::cuda::par.on(single_context->stream()),
+          thrust::hip::par.on(single_context->stream()),
           thrust::make_counting_iterator<index_t>(0),     // Begin: 0
           thrust::make_counting_iterator<index_t>(size),  // End: # of V/E
           [=] __device__(index_t const& x) { op(x); }     // Unary Operator

--- a/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
+++ b/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
@@ -71,7 +71,7 @@ void execute(graph_t& G,
     using type_t = typename graph_t::vertex_type;
     using find_csr_t = typename graph_t::graph_csr_view_t;
     if (!(G.template contains_representation<find_csr_t>())) {
-      error::throw_if_exception(cudaErrorUnknown,
+      error::throw_if_exception(hipErrorUnknown,
                                 "CSR sparse-matrix representation "
                                 "required for neighborreduce operator.");
     }

--- a/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
+++ b/include/gunrock/framework/operators/neighborreduce/neighborreduce.hxx
@@ -17,8 +17,6 @@
 
 #include <gunrock/framework/operators/configs.hxx>
 
-#include <moderngpu/kernel_segreduce.hxx>
-
 // #define LBS_SEGREDUCE 1
 
 namespace gunrock {
@@ -78,10 +76,7 @@ void execute(graph_t& G,
 
 #ifndef LBS_SEGREDUCE
     // TODO: Throw an exception if input_t is not advance_io_type_t::graph.
-    mgpu::transform_segreduce(op, G.get_number_of_edges(), G.get_row_offsets(),
-                              G.get_number_of_vertices(), output, arithmetic_op,
-                              init_value, *(context0->mgpu()));
-
+    assert(false);
 #else
 
     auto f = [=] __device__(std::size_t index, std::size_t seg,
@@ -93,9 +88,7 @@ void execute(graph_t& G,
     };
 
     // TODO: Throw an exception if input_t is not advance_io_type_t::graph.
-    mgpu::lbs_segreduce(f, G.get_number_of_edges(), G.get_row_offsets(),
-                        G.get_number_of_vertices(), output, arithmetic_op,
-                        init_value, *(context0->mgpu()));
+    assert(false);
 #endif
   }
 }

--- a/include/gunrock/framework/operators/uniquify/unique.hxx
+++ b/include/gunrock/framework/operators/uniquify/unique.hxx
@@ -24,7 +24,7 @@ void execute(frontier_t* input,
              frontier_t* output,
              gcuda::standard_context_t& context) {
   auto new_end = thrust::unique(
-      thrust::cuda::par.on(context.stream()),  // execution policy
+      thrust::hip::par.on(context.stream()),  // execution policy
       input->begin(),                          // input iterator: begin
       input->end()                             // input iterator: end
   );

--- a/include/gunrock/framework/operators/uniquify/unique_copy.hxx
+++ b/include/gunrock/framework/operators/uniquify/unique_copy.hxx
@@ -28,7 +28,7 @@ void execute(frontier_t* input,
     output->reserve(input->get_number_of_elements());
 
   auto new_end = thrust::unique_copy(
-      thrust::cuda::par.on(context.stream()),  // execution policy
+      thrust::hip::par.on(context.stream()),  // execution policy
       input->begin(),                          // input iterator: begin
       input->end(),                            // input iterator: end
       output->begin()                          // output iterator: begin

--- a/include/gunrock/framework/operators/uniquify/uniquify.hxx
+++ b/include/gunrock/framework/operators/uniquify/uniquify.hxx
@@ -30,13 +30,13 @@ void execute(frontier_t* input,
         input->sort(sort::order_t::ascending, single_context->stream());
       unique_copy::execute(input, output, *single_context);
     } else {
-      error::throw_if_exception(cudaErrorUnknown, "Unqiue type not supported.");
+      error::throw_if_exception(hipErrorUnknown, "Unqiue type not supported.");
     }
   }
 
   // Multi-GPU not supported.
   else {
-    error::throw_if_exception(cudaErrorUnknown,
+    error::throw_if_exception(hipErrorUnknown,
                               "`context.size() != 1` not supported");
   }
 }
@@ -51,7 +51,7 @@ void execute(enactor_type* E,
   if (!best_effort_uniquification)
     if (uniquification_percent < 0 || uniquification_percent > 100)
       error::throw_if_exception(
-          cudaErrorUnknown,
+          hipErrorUnknown,
           "Uniquification percentage must be a +ve float between 0 and 100.");
 
   execute<type>(E->get_input_frontier(),     // input frontier

--- a/include/gunrock/graph/conversions/convert.hxx
+++ b/include/gunrock/graph/conversions/convert.hxx
@@ -21,7 +21,7 @@ void offsets_to_indices(const index_t* offsets,
                         offset_t* indices,
                         index_t const& size_of_indices) {
   using execution_policy_t = std::conditional_t<space == memory_space_t::device,
-                                                decltype(thrust::cuda::par.on(
+                                                decltype(thrust::hip::par.on(
                                                     0)),  // XXX: does this
                                                           // work on stream 0?
                                                 decltype(thrust::host)>;

--- a/include/gunrock/graph/detail/build.hxx
+++ b/include/gunrock/graph/detail/build.hxx
@@ -84,7 +84,7 @@ auto from_csr(vertex_t const& r,
               edge_t* column_offsets = nullptr) {
   if constexpr (has(build_views, view_t::csc) &&
                 has(build_views, view_t::csr)) {
-    error::throw_if_exception(cudaErrorUnknown,
+    error::throw_if_exception(hipErrorUnknown,
                               "CSC & CSR view not yet supported together.");
   }
 

--- a/include/gunrock/graph/graph.hxx
+++ b/include/gunrock/graph/graph.hxx
@@ -376,7 +376,7 @@ void build_degree_histogram(graph_type const& G,
   auto length = sizeof(vertex_t) * 8 + 1;
 
   // Initialize histogram array to 0s.
-  thrust::fill(thrust::cuda::par.on(stream),
+  thrust::fill(thrust::hip::par.on(stream),
                histogram + 0,       // iterator begin()
                histogram + length,  // iterator end()
                0                    // fill value
@@ -395,7 +395,7 @@ void build_degree_histogram(graph_type const& G,
   // For each (count from 0...#_of_Vertices), and perform
   // the operation called build_histogram. Ignore output, as
   // we are interested in what goes in the pointer histogram.
-  thrust::for_each(thrust::cuda::par.on(stream),
+  thrust::for_each(thrust::hip::par.on(stream),
                    thrust::make_counting_iterator<vertex_t>(0),  // Begin: 0
                    thrust::make_counting_iterator<vertex_t>(
                        G.get_number_of_vertices()),  // End: # of Vertices

--- a/include/gunrock/memory.hxx
+++ b/include/gunrock/memory.hxx
@@ -24,10 +24,10 @@ namespace memory {
  * @brief memory space; cuda (device) or host.
  * Can be extended to support uvm and multi-gpu.
  *
- * @todo change this enum to support cudaMemoryType
- * (see ref;  std::underlying_type<cudaMemoryType>::type)
+ * @todo change this enum to support hipMemoryType
+ * (see ref;  std::underlying_type<hipMemoryType>::type)
  * instead of some random enums, we can rely
- * on cudaMemoryTypeHost/Device/Unregistered/Managed
+ * on hipMemoryTypeHost/Device/Unregistered/Managed
  * for this.
  *
  */
@@ -47,8 +47,8 @@ void allocate(type_t* pointer,
               memory_space_t space = memory_space_t::device) {
   if (size) {
     error::throw_if_exception((device == space)
-                                  ? cudaMalloc(&pointer, size)
-                                  : cudaMallocHost(&pointer, size));
+                                  ? hipMalloc(&pointer, size)
+                                  : hipHostMalloc(&pointer, size));
   }
 }
 
@@ -66,8 +66,8 @@ inline type_t* allocate(std::size_t size,
   void* pointer = nullptr;
   if (size) {
     error::throw_if_exception((device == space)
-                                  ? cudaMalloc(&pointer, size)
-                                  : cudaMallocHost(&pointer, size));
+                                  ? hipMalloc(&pointer, size)
+                                  : hipHostMalloc(&pointer, size));
   }
   return reinterpret_cast<type_t*>(pointer);
 }
@@ -83,8 +83,8 @@ template <typename type_t>
 inline void free(type_t* pointer,
                  memory_space_t space = memory_space_t::device) {
   if (pointer) {
-    error::throw_if_exception((device == space) ? cudaFree((void*)pointer)
-                                                : cudaFreeHost((void*)pointer));
+    error::throw_if_exception((device == space) ? hipFree((void*)pointer)
+                                                : hipHostFree((void*)pointer));
   }
 }
 

--- a/include/gunrock/util/compare.hxx
+++ b/include/gunrock/util/compare.hxx
@@ -43,7 +43,7 @@ std::size_t compare(const type_t* d_ptr,
                     comp_t error_op = detail::default_comparator,
                     const bool verbose = false) {
   thrust::host_vector<type_t> d_vec(n);
-  cudaMemcpy(d_vec.data(), d_ptr, n * sizeof(type_t), cudaMemcpyDeviceToHost);
+  hipMemcpy(d_vec.data(), d_ptr, n * sizeof(type_t), hipMemcpyDeviceToHost);
 
   std::size_t error_count = 0;
   for (std::size_t i = 0; i < n; ++i) {

--- a/include/gunrock/util/load_store.hxx
+++ b/include/gunrock/util/load_store.hxx
@@ -9,7 +9,7 @@
  *
  */
 #pragma once
-#include <cub/cub.cuh>
+#include <hipcub/hipcub.hpp>
 
 namespace gunrock {
 namespace thread {
@@ -18,11 +18,11 @@ namespace thread {
  * @brief Uses a cached load to load a value from a given pointer.
  */
 template <
-    cub::CacheLoadModifier MODIFIER = cub::CacheLoadModifier::LOAD_DEFAULT,
+    hipcub::CacheLoadModifier MODIFIER = hipcub::CacheLoadModifier::LOAD_DEFAULT,
     typename type_t>
 __device__ __host__ __forceinline__ type_t load(type_t* ptr) {
 #ifdef __CUDA_ARCH__
-  return cub::ThreadLoad<MODIFIER>(ptr);
+  return hipcub::ThreadLoad<MODIFIER>(ptr);
 #else
   return *ptr;
 #endif
@@ -32,11 +32,11 @@ __device__ __host__ __forceinline__ type_t load(type_t* ptr) {
  * @brief Uses a cached store to store a given value into a pointer.
  */
 template <
-    cub::CacheStoreModifier MODIFIER = cub::CacheStoreModifier::STORE_DEFAULT,
+    hipcub::CacheStoreModifier MODIFIER = hipcub::CacheStoreModifier::STORE_DEFAULT,
     typename type_t>
 __device__ __host__ __forceinline__ void store(type_t* ptr, const type_t& val) {
 #ifdef __CUDA_ARCH__
-  cub::ThreadStore<MODIFIER>(ptr, val);
+  hipcub::ThreadStore<MODIFIER>(ptr, val);
 #else
   *ptr = val;
 #endif

--- a/include/gunrock/util/math.hxx
+++ b/include/gunrock/util/math.hxx
@@ -74,6 +74,10 @@ constexpr const type_t& min(const type_t& a, const type_t& b) {
  */
 namespace atomic {
 
+#ifdef __HIP_DEVICE_COMPILE__
+#define __CUDA_ARCH__
+#endif
+
 template <typename type_t>
 __host__ __device__ __forceinline__ type_t add(type_t* address, type_t value) {
 #ifdef __CUDA_ARCH__
@@ -126,6 +130,12 @@ __host__ __device__ __forceinline__ type_t exch(type_t* address, type_t value) {
   *address = value;  // use std::atomic;
   return old;
 #endif
+
+
+#ifdef __HIP_DEVICE_COMPILE__
+#undef __CUDA_ARCH__
+#endif
+
 }
 
 }  // namespace atomic

--- a/include/gunrock/util/timer.hxx
+++ b/include/gunrock/util/timer.hxx
@@ -18,25 +18,25 @@ struct timer_t {
   float time;
 
   timer_t() {
-    cudaEventCreate(&start_);
-    cudaEventCreate(&stop_);
-    cudaEventRecord(start_);
+    hipEventCreate(&start_);
+    hipEventCreate(&stop_);
+    hipEventRecord(start_);
   }
 
   ~timer_t() {
-    cudaEventDestroy(start_);
-    cudaEventDestroy(stop_);
+    hipEventDestroy(start_);
+    hipEventDestroy(stop_);
   }
 
   // Alias of each other, start the timer.
-  void begin() { cudaEventRecord(start_); }
+  void begin() { hipEventRecord(start_); }
   void start() { this->begin(); }
 
   // Alias of each other, stop the timer.
   float end() {
-    cudaEventRecord(stop_);
-    cudaEventSynchronize(stop_);
-    cudaEventElapsedTime(&time, start_, stop_);
+    hipEventRecord(stop_);
+    hipEventSynchronize(stop_);
+    hipEventElapsedTime(&time, start_, stop_);
 
     return milliseconds();
   }
@@ -46,7 +46,7 @@ struct timer_t {
   float milliseconds() { return time; }
 
  private:
-  cudaEvent_t start_, stop_;
+  hipEvent_t start_, stop_;
 };
 
 }  // namespace util


### PR DESCRIPTION
I wanted to see perf of gunrock things on AMD. Hipifying source with
```
find . -name "*.hxx" -o -name "*.cu" -exec hipify-perl {} -inplace \;
```
went relatively well. (Had to attach rocthrust, hipCub, etc, as well and hack around CUDA_ARCH. Moderngpu is also hipified but if you touch it, it will break. I'll try and add the 'hipification' as a cmake target, so you won't need to commit any changed files. It'll execute hipify-perl and then compile the modified source. In the meantime I'll use this PR to mess about with this. )

Here's a comparison between MI200 (gfx908) and A100 (ampere). 

| ./bin/bfs <>                   | A100 (NVIDIA)        | MI200 (AMD)           | % Improvement (+ AMD) |
| -------------           | -------------           | --------------------- |  -------------------------  |
| road_usa                 |  2183.99ms   |  577.13ms | +73.6% |
| kron_g500-logn20  | 16.081ms   | 14.8162ms | +7.89% |

Term output below:
```
carozhon@wario:~/wario/essentials/build$ ./bin/bfs-HIP /data/gunrock/gunrock_dataset/luigi-8TB/kron_g500-logn20.mtx
gfx908 : BUS: 163:0 : 1502 Mhz (Ordinal 0)
FreeMem: 32752 MB TotalMem: 32752 MB 64-bit pointers.
120 SMs enabled, Compute Capability sm_90
Mem Clock: 1200 Mhz x 4096 bits (1228.8 GB/s)
ECC Disabled
GPU distances[:40] = 0 3 3 3 3 2147483647 3 3 3 2147483647 3 3 3 3 2 3 3 3 3 3 3 3 3 2147483647 2147483647 3 3 3 2147483647 3 3 2147483647 3 2147483647 3 3 2 2147483647 3 2147483647
CPU Distances[:40] = 0 3 3 3 3 2147483647 3 3 3 2147483647 3 3 3 3 2 3 3 3 3 3 3 3 3 2147483647 2147483647 3 3 3 2147483647 3 3 2147483647 3 2147483647 3 3 2 2147483647 3 2147483647
GPU Elapsed Time : 14.8162 (ms)
CPU Elapsed Time : 350.112 (ms)
Number of errors : 0

carozhon@wario:~/wario/cuda-essentials/build$ ./bin/bfs /data/gunrock/gunrock_dataset/luigi-8TB/kron_g500-logn20.mtx
NVIDIA A100-PCIE-40GB : 1410 Mhz (Ordinal 0)
FreeMem: 39862 MB TotalMem: 40354 MB 64-bit pointers.
108 SMs enabled, Compute Capability sm_80
Mem Clock: 1215 Mhz x 5120 bits (1555.2 GB/s)
ECC Disabled
GPU distances[:40] = 0 3 3 3 3 2147483647 3 3 3 2147483647 3 3 3 3 2 3 3 3 3 3 3 3 3 2147483647 2147483647 3 3 3 2147483647 3 3 2147483647 3 2147483647 3 3 2 2147483647 3 2147483647
CPU Distances[:40] = 0 3 3 3 3 2147483647 3 3 3 2147483647 3 3 3 3 2 3 3 3 3 3 3 3 3 2147483647 2147483647 3 3 3 2147483647 3 3 2147483647 3 2147483647 3 3 2 2147483647 3 2147483647
GPU Elapsed Time : 16.0891 (ms)
CPU Elapsed Time : 364.97 (ms)
Number of errors : 0
carozhon@wario:~/wario/cuda-essentials/build$ ./bin/bfs /data/gunrock/gunrock_dataset/luigi-8TB/large/road_usa/road_usa.mtx
NVIDIA A100-PCIE-40GB : 1410 Mhz (Ordinal 0)
FreeMem: 39862 MB TotalMem: 40354 MB 64-bit pointers.
108 SMs enabled, Compute Capability sm_80
Mem Clock: 1215 Mhz x 5120 bits (1555.2 GB/s)
ECC Disabled
GPU distances[:40] = 0 1 123 41 124 123 128 129 123 122 123 122 3 120 121 126 127 128 123 120 114 110 103 102 104 119 118 118 117 113 29 30 114 113 106 102 100 19 20 99
CPU Distances[:40] = 0 1 123 41 124 123 128 129 123 122 123 122 3 120 121 126 127 128 123 120 114 110 103 102 104 119 118 118 117 113 29 30 114 113 106 102 100 19 20 99
GPU Elapsed Time : 2183.99 (ms)
CPU Elapsed Time : 2328.56 (ms)
Number of errors : 0
carozhon@wario:~/wario/essentials/build$ ./bin/bfs-HIP /data/gunrock/gunrock_dataset/luigi-8TB/large/road_usa/road_usa.mtx
gfx908 : BUS: 163:0 : 1502 Mhz (Ordinal 0)
FreeMem: 32752 MB TotalMem: 32752 MB 64-bit pointers.
120 SMs enabled, Compute Capability sm_90
Mem Clock: 1200 Mhz x 4096 bits (1228.8 GB/s)
ECC Disabled
GPU distances[:40] = 0 1 123 41 124 123 128 129 123 122 123 122 3 120 121 126 127 128 123 120 114 110 103 102 104 119 118 118 117 113 29 30 114 113 106 102 100 19 20 99
CPU Distances[:40] = 0 1 123 41 124 123 128 129 123 122 123 122 3 120 121 126 127 128 123 120 114 110 103 102 104 119 118 118 117 113 29 30 114 113 106 102 100 19 20 99
GPU Elapsed Time : 577.13 (ms)
CPU Elapsed Time : 2255.8 (ms)
```